### PR TITLE
Formalize GPT-4

### DIFF
--- a/src/posts/faq.md
+++ b/src/posts/faq.md
@@ -17,7 +17,8 @@ You can mail us at [pauseai@proton.me](mailto:pauseai@proton.me).
 ### Do you want to ban all AI?
 
 No, only the development of the largest general-purpose AI systems, often called "Frontier models".
-All existing AI would be legal under our proposal, and many future AI models will remain legal, too.
+We're calling for a ban on AI systems more powerful than GPT-4.
+All currently existing AI would be legal under our proposal, and most future AI models will remain legal, too.
 
 ### Who is paying you?
 

--- a/src/posts/faq.md
+++ b/src/posts/faq.md
@@ -24,6 +24,7 @@ All currently existing AI would be legal under our proposal, and most future AI 
 
 We have not received funding so far.
 Everyone contributing to PauseAI is doing so voluntarily.
+We expect to receive a grant through the LightSpeed network soon, and people have approached us that they are willing to donate.
 
 ### If we Pause, how about China?
 

--- a/src/posts/proposal.md
+++ b/src/posts/proposal.md
@@ -26,6 +26,7 @@ This treaty needs to be signed by all UN member states.
   - Granting approval for _new training runs_ of AI models above a certain size (e.g. 1 billion parameters).
   - Periodic meetings to discuss the progress of AI safety research.
 - **Only allow training of general AI systems more powerful than GPT-4 if their safety can be guaranteed**.
+  - By more powerful than GPT-4, we mean all AI models that are either larger than 10^12 parameters or having more than 10^25 FLOPs used for training.
   - Note that this does not target _narrow_ AI systems, like image recognition used for diagnosing cancer.
   - Require [oversight during training runs](https://www.alignmentforum.org/posts/Zfk6faYvcf5Ht7xDx/compute-thresholds-proposed-rules-to-mitigate-risk-of-a-lab).
   - Safety can be guaranteed if there is strong scientific consensus and [proof](https://arxiv.org/abs/2309.01933) that the _alignment problem has been solved_. Right now, this is not the case, so right now we should not allow training of such systems.

--- a/src/posts/summit.md
+++ b/src/posts/summit.md
@@ -7,7 +7,7 @@ AI presents numerous [risks](/risks) to humanity, including the [risk of extinct
 Progress in AI capabilities is accelerating at a [frantic pace](/urgency), and we are not prepared for the consequences.
 AI companies are locked in a race to the bottom, where safety is not the highest priority.
 We need governments to step in and prevent AI from reaching superhuman levels before we know how to make it safely.
-This pause needs to happen on an international level, because countries are locked in a race similar to the companies.
+This pause needs to happen on an international level because countries are locked in a race similar to the companies.
 
 **The only way to achieve a true pause is through a summit.**
 

--- a/src/posts/summit.md
+++ b/src/posts/summit.md
@@ -1,26 +1,33 @@
 ---
-title: AI Safety Summit
-description: What it would take to organize a successful summit on AI safety.
+title: Towards the next AI Safety Summit
+description: Why we need the AI safety summit to happen, and what it should achieve.
 ---
 
-AI presents very real risks to humanity, including the [risk of extinction](/xrisk).
+AI presents numerous [risks](/risks) to humanity, including the [risk of extinction](/xrisk).
 Progress in AI capabilities is accelerating at a [frantic pace](/urgency), and we are not prepared for the consequences.
 AI companies are locked in a race to the bottom, where safety is not the highest priority.
-We need governments to step in and regulate AI development.
-This needs to happen on an international level.
-**The only way to achieve this is through a summit.**
+We need governments to step in and prevent AI from reaching superhuman levels before we know how to make it safely.
+This pause needs to happen on an international level, because countries are locked in a race similar to the companies.
 
-The primary goal of PauseAI was to convince one government to organize such a summit.
-Just 5 weeks after the first PauseAI protest, the UK government has [announced](https://www.gov.uk/government/news/uk-to-host-first-global-summit-on-artificial-intelligence) that they will host an AI safety summit in on November 1-2 in London.
-This is amazing news, and we commend the UK government for taking this step.
-However, this does not mean that we're done.
+**The only way to achieve a true pause is through a summit.**
 
-## What is aim of a summit?
+## What should an AI summit achieve?
 
 The goal of a Summit is often a _treaty_, which is a formal agreement between two or more states in reference to peace, alliance, commerce, or other international relations.
 In our case, we are hoping for AI Safety Treaty which would be an agreement between the participating states to pause AI development until the risks are better understood.
 
-## Examples of Summits and resulting treaties
+## 2023 UK AI Safety Summit
+
+The primary goal of PauseAI was to convince one government to organize such a summit.
+Just 5 weeks after the first PauseAI protest, the UK government [announced](https://www.gov.uk/government/news/uk-to-host-first-global-summit-on-artificial-intelligence) that they would host an AI safety summit, which was held on November 1st and 2nd 2023.
+The summit was relatively small (only 100 people were invited) and was held in Bletchley Park.
+It did not lead to a treaty, unfortunately.
+However, it did lead to the ["Bletchley Declaration"](https://www.gov.uk/government/publications/ai-safety-summit-2023-the-bletchley-declaration/the-bletchley-declaration-by-countries-attending-the-ai-safety-summit-1-2-november-2023), which was signed by all 28 attending countries.
+In this declaration, the countries acknowledged AI risks (including 'issues of control relating to alignment with human intent').
+In our opinion, this declaration is an important first step, yet it is far from enough.
+We need an actual binding treaty that pauses frontier AI development.
+
+## Examples of Summits and resulting in treaties
 
 - **Montreal Protocol** (1987): The Montreal Protocol is an international environmental treaty designed to protect the ozone layer by phasing out the production and consumption of ozone-depleting substances. It has been highly successful in reducing the use of substances like chlorofluorocarbons (CFCs) and has contributed to the gradual recovery of the ozone layer.
 - **Stockholm Convention on Persistent Organic Pollutants** (2001): The Stockholm Convention is an international treaty aimed at protecting human health and the environment from persistent organic pollutants (POPs). These are toxic chemicals that persist in the environment, bioaccumulate in living organisms, and can have serious adverse effects on human health and ecosystems. Scientists raised concerns about the harmful effects of POPs, including their ability to travel long distances through air and water currents. The convention led to the banning or severe restrictions on the production and use of several POPs, including polychlorinated biphenyls (PCBs), dichlorodiphenyltrichloroethane (DDT), and dioxins.


### PR DESCRIPTION
We hadn't specified "more powerful than GPT-4". How about this?

```
By more powerful than GPT-4, we mean all AI models that are either
larger than 10^12 parameters or
having more than 10^25 FLOPs used for training.
 ```
 
Some thoughts:

- We don't know the exact parameter count / flops used for GPT-4.
- Not sure if it's bad if GPT-4 will also be banned under this proposal.
- We've seen smaller models become far more capable. Perhaps we should have a limit on capabilities as well? Harder to define before the training run though, and this is already covered by most policy proposals that use dangerous capability evals (e.g. RSP)