### PR TITLE
Changes to learn, and redirections to learn and faq

### DIFF
--- a/src/lib/components/Doomers.svelte
+++ b/src/lib/components/Doomers.svelte
@@ -148,9 +148,9 @@
 		{
 			name: 'Eliezer Yudkowsky',
 			title: 'Founder of MIRI',
-			probability: '>80%',
-			number: 0.8,
-			source: 'https://twitter.com/ESYudkowsky/status/1662247373014286337'
+			probability: '>99%',
+			number: 0.99,
+			source: 'https://www.lesswrong.com/posts/j9Q8bRmwCgXRYAgcJ/miri-announces-new-death-with-dignity-strategy'
 		}
 	]
 </script>

--- a/src/posts/faq.md
+++ b/src/posts/faq.md
@@ -149,4 +149,5 @@ Because acknowledging that _we are in fact in danger_ is a very, very scary thin
 
 ### I have a different / AI related question
 
-Try [AIsafety.info](https://aisafety.info/), an awesome database of questions and answers about AI safety.
+You can learn about AI Safety in other [videos, other media and articles here](/learn).
+Or learn about it more interactively and see the whole AI Safety landscape in [AISafety.com](https://www.aisafety.com).

--- a/src/posts/learn.md
+++ b/src/posts/learn.md
@@ -44,3 +44,14 @@ Here are some resources to get you started.
 - [Human Compatible: Artificial Intelligence and the Problem of Control](https://www.goodreads.com/en/book/show/44767248) (Stuart Russell)
 - [Our Final Invention: Artificial Intelligence and the End of the Human Era](https://www.goodreads.com/en/book/show/17286699) (James Barrat)
 - [The Precipice: Existential Risk and the Future of Humanity](https://www.goodreads.com/en/book/show/50963653) (Toby Ord)
+
+# If you are convinced and want to take action
+
+There are many [things that you can do](/action).
+Writing a letter, going to a protest, donating some money or joining a community is not that hard!
+And these actions have a real impact.
+Even when facing the end of the world, there can still be hope and very rewarding work to do.
+
+# If you still don't feel quite sure of it
+
+Learning about the [psychology of x-risk](/psychology-of-x-risk) could help you.

--- a/src/posts/learn.md
+++ b/src/posts/learn.md
@@ -8,57 +8,34 @@ Here are some resources to get you started.
 
 ## Videos
 
+- [Could AI wipe out humanity?](https://youtu.be/qzyEgZwfkKY?si=ief1l2PpkZ7_s6sq) (10 mins). The best shortest and simple introduction to the problem, from a down-to-earth perspective. 
 - [Don't look up - The Documentary: The Case For AI As An Existential Threat](https://www.youtube.com/watch?v=U1eyUjVRir4) (17 mins). Powerful and nicely edited documentary about the dangers of AI, with many expert quotes from interviews.
-- [How to get Empowered, not overpowered by AI](https://www.youtube.com/watch?v=2LRwvU6gEbA) (15 mins). A brief introduction to the importance of getting AI alignment right.
-- [Robert Miles' YouTube videos](https://www.youtube.com/watch?v=tlS5Y2vm02c&list=PLfHsskCxi_g-c62a_dmsNuHynaXsRQm40) are a great place to start understanding most of the fundamentals of AI alignment.
-- [Max Tegmark with Lex interview](https://youtu.be/VcVfceTsD0A?t=1547) (2 hrs). Interview that dives into the details of our current dangerous situation. _"It's like 'Don't look up', but we are building the asteroid ourselves."_
 - [Max Tegmark Ted Talk (2023)](https://www.youtube.com/watch?v=xUNx_PxNHrY) (15 mins). AI capabilities are improving quicker than expected.
-- [The AI Dilemma](https://www.youtube.com/watch?v=xoVJKj8lcNQ&t=1903s) (1hr). Presentation about the dangers of AI and the race which AI companies are stuck in.
-- [How not to destroy the world with AI](https://www.youtube.com/watch?v=ISkAkiAkK7A) (1hr). Presentation by Stuart Russell.
+- [Sam Harris | Can we build AI without losing control over it?](https://www.youtube.com/watch?v=8nt3edWLgIg) (15 mins). Ted talk about the crazy situation we're in.
 - [Exploring the dangers from Artificial Intelligence](https://www.youtube.com/watch?v=sPyu_dTSma0&t=1328s) (25mins). Summary of cybersecurity, biohazard and power-seeking AI risks.
+- [The AI Dilemma](https://www.youtube.com/watch?v=xoVJKj8lcNQ&t=1903s) (1hr). Presentation about the dangers of AI and the race which AI companies are stuck in.
+- [Robert Miles' YouTube videos](https://www.youtube.com/watch?v=tlS5Y2vm02c&list=PLfHsskCxi_g-c62a_dmsNuHynaXsRQm40) are a great place to start understanding most of the fundamentals of AI alignment.
 
 ## Websites
 
-- [AISafety.info](https://aisafety.info/). Very complete database of questions and answers.
-- [NavigatingAIRisks.ai](https://www.navigatingrisks.ai/). A blog with various interesting articles.
+- [AISafety.com](https://www.aisafety.com). The new landing page for AI Safety. Learn about the risks, the landscape, the communities, the events, the jobs, the courses, the ideas for solutions and more!
 - [IncidentDatabase.ai](https://incidentdatabase.ai/). Database of incidents where AI systems caused harm.
+- [NavigatingAIRisks.ai](https://www.navigatingrisks.ai/). A blog with various interesting articles.
 
 ## Podcasts
 
-- [AI X-Risk Research podcast](https://axrp.net/). In-depth interviews with experts in the field of AI alignment.
-- [Future of Life podcast](https://soundcloud.com/futureoflife)
+- [Future of Life Institute | Connor Leahy on AI Safety and Why the World is Fragile](https://youtu.be/cSL3Zau1X8g?si=0X3EKoxZ80_HN9Rl&t=1803). Interview with Connor about the AI Safety strategies.
+- [Lex Fridman | Max Tegmark: The Case for Halting AI Development](https://youtu.be/VcVfceTsD0A?t=1547). Interview that dives into the details of our current dangerous situation.
+- [Connor Leahy, AI Fire Alarm](https://youtu.be/pGjyiqJZPJo?t=2510). Connor talking about the intelligence explosion being the most important thing that could ever happen.
+- [The 80,000 Hours Podcast recommended episodes on AI](https://80000hours.org/podcast/on-artificial-intelligence/). Not 80k hours long, but a compilation of episodes of The 80,000 Hours Podcast about AI Safety.
+- [Future of Life Institute Podcast episodes on AI](https://futureoflife.org/podcast/?_category_browser=ai). All of the episodes of the FLI Podcast on the future of Artificial Intelligence.
 
 ## Articles
 
 - [The 'Don't Look Up' Thinking That Could Doom Us With AI](https://time.com/6273743/thinking-that-could-doom-us-with-ai/) (by Max Tegmark)
 - [Pausing AI Developments Isn't Enough. We Need to Shut it All Down](https://time.com/6266923/ai-eliezer-yudkowsky-open-letter-not-enough/) (by Eliezer Yudkowsky)
-- [Preventing an AI-related catastrophe](https://80000hours.org/problem-profiles/artificial-intelligence/) (by 80,000 hours)
 - [The AI Revolution: The Road to Superintelligence](https://waitbutwhy.com/2015/01/artificial-intelligence-revolution-1.html) (by WaitButWhy)
-- [AI Alignment, Explained in 5 Points](https://medium.com/@daniel_eth/ai-alignment-explained-in-5-points-95e7207300e3)
 - [How rogue AIs may arise](https://yoshuabengio.org/2023/05/22/how-rogue-ais-may-arise/) (by Yoshua Bengio)
-- [A simple explanation of why advanced AI could be incredibly dangerous](https://muddyclothes.substack.com/p/a-simple-explanation-of-why-advanced)
-
-## Courses
-
-- [AGI safety fundamentals](https://www.agisafetyfundamentals.com/) (30hrs)
-- [CHAI Bibliography of Recommended Materials](https://humancompatible.ai/bibliography) (50hrs+)
-- [AIsafety.training](https://aisafety.training/): Overview of training programs, conferences, and other events
-
-## Organisations
-
-- [Future of Life Institute](https://futureoflife.org/cause-area/artificial-intelligence/) started the [open letter](https://futureoflife.org/open-letter/pause-giant-ai-experiments/), led by Max Tegmark.
-- [FutureSociety](https://thefuturesociety.org/about-us/)
-- [Conjecture](https://www.conjecture.dev/). Start-up that is working on AI alignment and AI policy, led by Connor Leahy.
-- [Existential Risk Observatory](https://existentialriskobservatory.org/). Dutch organization that is informing the public on x-risks and studying communication strategies.
-- [Center for AI Safety](https://www.safe.ai/) (CAIS) is a research center at the Czech Technical University in Prague, led by
-- [Center for Human-Compatible Artificial Intelligence](https://humancompatible.ai/about/) (CHAI), led by Stuart Russell.
-- [Machine Intelligence Research Institute](https://intelligence.org/) (MIRI), doing mathematical research on AI safety, led by Eliezer Yudkowsky.
-- [Centre for the Governance of AI](https://www.governance.ai/)
-- [Institute for AI Policy and Strategy](https://www.iaps.ai/) (IAPS)
-- [The AI Policy Institute](https://theaipi.org/)
-- [AI Safety Communications Centre](https://aiscc.org/2023/11/01/yougov-poll-83-of-brits-demand-companies-prove-ai-systems-are-safe-before-release/)
-- [The Midas Project](https://www.themidasproject.com/) Corporate pressure campaigns for AI safety.
-- [The Human Survival Project](https://thehumansurvivalproject.org/)
 
 ## Books
 


### PR DESCRIPTION
Changes to learn:

Videos
- added 80k intro to AIS
- added Sam Harris Ted Talk
- moved Tegmark x Lex to "Podcasts"
- deleted a Tegmark Ted talk (it looked to me like too much stuff from him and the new version is like an updated v).
- deleted the 1h talk from Russell bc I thought it was a bit too technical
- ordered the videos from shortest to longest

Websites:
- changed ais.info to ais.com and the desc

Podcasts:
Less technical and to the point content/ links (put specific episodes with specific timestamps or lists of episodes).

Articles:
Deleted some because prefer if people don't go and re-read the same stuff in different ways. So the options are more so people can choose between people or outlets they could known.

Deleted courses:
I just think they are unnecesary as the more technical content, most of these circles already redirectionate everyone too do research while I don't think that is the best strategy

Deleted organizations:
I think they occupied a bunch of space, are kinda arbitrary, difficult to have up to date, not that useful and that aisafety.world/tiles already do such an amazing job at it that maybe I should've add it after aisafety.com

Added Redirections:
To learn and faq at the end, I think every page should have at least one