### PR TITLE
Fix Schema.org markup

### DIFF
--- a/src/lib/components/PostMeta.svelte
+++ b/src/lib/components/PostMeta.svelte
@@ -15,7 +15,7 @@
 		datePublished: date,
 		image: {
 			'@type': 'ImageObject',
-			contentUrl: imageUrl
+			url: imageUrl
 		}
 	}
 </script>


### PR DESCRIPTION
The [Google Search Console ](https://search.google.com/test/rich-results/result/r%2Farticles?id=5JRts2_x2Sntp3qzWaBKnw)wants the image to have an `url` instead of a `contentUrl`, I don't know why I didn't catch that earlier.