### PR TITLE
Apply default link style everywhere and update license

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -108,6 +108,15 @@ h1 {
 	}
 }
 
+a {
+	color: var(--brand-subtle);
+	text-decoration: underline;
+}
+
+a:hover {
+	color: var(--brand);
+}
+
 .prose {
 	line-height: 1.5em;
 }
@@ -130,15 +139,6 @@ h1 {
 .prose :is(ul, ol) li {
 	margin-block: 0.3rem;
 	padding-inline-start: 0.5rem;
-}
-
-.prose a {
-	color: var(--brand-subtle);
-	text-decoration: underline;
-}
-
-.prose a:hover {
-	color: var(--brand);
 }
 
 .prose pre {

--- a/src/routes/footer.svelte
+++ b/src/routes/footer.svelte
@@ -58,7 +58,7 @@
 		<ExternalLink href={editUrl}>Edit this page</ExternalLink>
 		<a href="/posts">All pages</a>
 		<a href="/rss.xml" target="_blank">RSS</a>
-		<ExternalLink href="https://creativecommons.org/licenses/by/2.0/" target="_blank">License: CC-BY 2.0</ExternalLink>
+		<ExternalLink href="https://creativecommons.org/licenses/by/4.0/" target="_blank">License: CC-BY 4.0</ExternalLink>
 	</div>
 </footer>
 


### PR DESCRIPTION
- Applied the default link style to everywhere there isn't a specific link style, including the pages that aren't written in Markdown, which currently aren't covered by ".prose". It seems reasonable to define a default link style in general, and I couldn't find anything where it has unintended consequences.
- Updated the license to CC-BY 4.0 in accordance with the LICENSE file on GitHub