### PR TITLE
Keep nav links centered when split across multiple lines

### DIFF
--- a/src/routes/header.svelte
+++ b/src/routes/header.svelte
@@ -39,6 +39,7 @@
 		display: flex;
 		text-transform: uppercase;
 		flex-wrap: wrap;
+		justify-content: center;
 	}
 
 	@media (min-width: 850px) {


### PR DESCRIPTION
Before:
![grafik](https://github.com/joepio/pauseai/assets/87208350/736be30c-4266-4df9-9768-c9edb29898d7)

After:
![grafik](https://github.com/joepio/pauseai/assets/87208350/92f9b8c4-fd91-4d34-aa9f-c945b9ab8f21)
