### PR TITLE
Align external link icon to not make the line higher

### DIFF
--- a/src/lib/components/custom/a.svelte
+++ b/src/lib/components/custom/a.svelte
@@ -30,7 +30,7 @@
 <style>
 	.icon {
 		display: inline-block;
-		vertical-align: middle;
+		vertical-align: text-top;
 		margin-left: 0.1em;
 	}
 </style>


### PR DESCRIPTION
I don't know why "text-top" works to align it at the bottom, but it does across multiple browsers.

Before:
![grafik](https://github.com/joepio/pauseai/assets/87208350/61919a5f-3624-4e69-8174-f87dc53d6689)

After:
![grafik](https://github.com/joepio/pauseai/assets/87208350/51371554-3f91-40ac-9110-bbc96e4bdcf9)

Text:
![grafik](https://github.com/joepio/pauseai/assets/87208350/60d9cb5d-9ed5-428d-873b-04bd52846d76)
