### PR TITLE
Add Donate button on GitHub

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: https://pauseai-shop.fourthwall.com/


### PR DESCRIPTION
Needs to be enabled under Settings -> General -> Features -> Sponsorships

I don't really expect anyone to find the button here, but it takes 30 seconds, so why not.