### PR TITLE
Embed DonorBox form on /littlehelpers page

### DIFF
--- a/src/lib/components/DonorBoxEmbed.svelte
+++ b/src/lib/components/DonorBoxEmbed.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+	import { onMount } from 'svelte'
+	import { getLocale } from '$lib/paraglide/runtime'
+
+	/** DonorBox campaign slug (required) */
+	export let campaignSlug: string
+
+	/** iframe height in pixels */
+	export let height = 685
+
+	/** Whether to enable PayPal Express in the widget */
+	export let paypalExpress = true
+
+	const locale = getLocale()
+	$: embedSrc = `https://donorbox.org/embed/${campaignSlug}?hide_donation_meter=true&language=${locale}`
+
+	onMount(() => {
+		const script = document.createElement('script')
+		script.src = 'https://donorbox.org/widget.js'
+		if (paypalExpress) {
+			script.setAttribute('paypalExpress', 'true')
+		}
+		document.body.appendChild(script)
+
+		return () => {
+			document.body.removeChild(script)
+		}
+	})
+</script>
+
+<div class="donorbox-container">
+	<iframe
+		src={embedSrc}
+		height="{height}px"
+		width="100%"
+		style="max-width: 500px; min-width: 310px;"
+		seamless
+		name="donorbox"
+		frameborder="0"
+		scrolling="no"
+		title="Donation form"
+	></iframe>
+</div>
+
+<style>
+	.donorbox-container {
+		display: flex;
+		justify-content: center;
+		margin: 2rem 0;
+	}
+</style>

--- a/src/lib/redirects.ts
+++ b/src/lib/redirects.ts
@@ -9,9 +9,7 @@ const REDIRECTS: Record<string, string> = {
 }
 
 /** Temporary redirects (302) - for time-limited campaigns, A/B tests, etc. */
-const TEMPORARY_REDIRECTS: Record<string, string> = {
-	'/littlehelpers': 'https://donorbox.org/pauseai-s-little-helpers'
-}
+const TEMPORARY_REDIRECTS: Record<string, string> = {}
 
 export function handleRedirects(path: string) {
 	const permanent = REDIRECTS[path]

--- a/src/posts/littlehelpers.md
+++ b/src/posts/littlehelpers.md
@@ -1,0 +1,22 @@
+---
+title: Little Helpers Campaign
+description: Help fund volunteer stipends for PauseAI advocates working to address AI safety concerns.
+---
+
+<script>
+	import DonorBoxEmbed from '$lib/components/DonorBoxEmbed.svelte'
+</script>
+
+Volunteers like Maxime, Raluca, and Mark are the heartbeat of PauseAI—from organizing protests in Paris to building chapters across four continents. This December, we're showcasing their work in daily videos.
+
+A €175/month stipend transforms a volunteer who can squeeze in a few hours on weekends into someone who can dedicate real time to this work. It's the difference between sending a few emails and leading a chapter, between attending one meeting and coordinating with policymakers.
+
+We're raising €21,000 to fund stipends for at least ten volunteers throughout 2026. Any funds beyond this goal will support volunteer microgrants.
+
+**Generous donors have pledged to match contributions through Christmas.**
+
+Help us grow this movement. Give the gift of dedicated advocacy this holiday season—become a Little Helper yourself.
+
+<DonorBoxEmbed campaignSlug="pauseai-s-little-helpers" />
+
+**Planning a larger contribution?** For donations of €1,000 or more, please [contact us](mailto:ella@pauseai.info) about IBAN transfers to minimize fees.


### PR DESCRIPTION
## Summary

- Replace `/littlehelpers` redirect with embedded DonorBox donation form
- Add reusable `DonorBoxEmbed.svelte` component with locale passthrough
- Add `littlehelpers.md` with campaign content matching DonorBox page text

## Details

Phase 1 of Little Helpers campaign integration (PauseAI/.github#5).

**DonorBox embed features:**
- Hides DonorBox's donation meter (`hide_donation_meter=true`) for future custom matching meter
- Passes site locale to DonorBox (`language=en`)
- Loads widget.js for PayPal Express support

**Content matches DonorBox campaign page:**
- Featured volunteers (Maxime, Raluca, Mark)
- €175/month stipend impact messaging
- €21,000 goal for 10 volunteers in 2026
- Matching announcement for Christmas
- Large donor IBAN transfer note

## Test plan

- [ ] Visit `/littlehelpers` on deploy preview
- [ ] Verify DonorBox form loads and is functional
- [ ] Confirm donation meter is hidden
- [ ] Check mailto link works for ella@pauseai.info

🤖 Generated with [Claude Code](https://claude.com/claude-code)