### PR TITLE
Revamp organization page with 2026 governance structure

### DIFF
--- a/src/posts/organization.md
+++ b/src/posts/organization.md
@@ -3,70 +3,101 @@ title: PauseAI Organization
 description: How the PauseAI organization is structured, and what resources are available for members.
 ---
 
-## Organization structure
+## How We're Structured
 
-- [Legal entities](/legal): PauseAI consists of one international entity (PauseAI Global), and several local / national legal entities. This website and the social media accounts are managed by the international entity.
-- [National groups](/national-groups): National PauseAI groups are hubs that typically manage their own local communities, and are responsible for national-level strategy and coordination. They typically have their own website, social media accounts and legal entity. National leaders meet regularly to coordinate their work.
-- [Teams](/teams): Teams are groups of volunteers who work on specific projects or tasks within PauseAI Global. Every team has its own leader, Discord channel, Drive folder and of course list of members. Reach out to a team leader to join a team!
-- [Communities](/communities): Check if there already exists a community in your area. Most groups are communicating in our discord server. Some groups are using tools like WhatsApp or a separate Discord server.
+PauseAI is a federation of local chapters coordinated by a global entity (PauseAI Global). This website and the main social media accounts are managed by PauseAI Global.
 
-![Organagram](/org.png)
+![Organagram](/org.svg)
 
-- [People](/about): Check out the individuals behind the board, international teams, and national groups.
+### Leadership
 
-## How teams work
+**Executive Team** — The decision-making body for PauseAI Global, composed of paid leadership staff. The Executive Team sets strategy, allocates resources, and coordinates the federation.
 
-- Teams take on certain responsibilities within PauseAI. They always have a leader, a Team Document (describing the team's responsibilities and processes), a Discord channel and a Drive folder. They typically regularly meet digitally to coordinate their work.
-- Read the [Team Lead Onboarding Document](https://docs.google.com/document/d/1obQTc4o3gSmTZ5WsvOWK9vG_7Ait6ZogDgrcj_ZKjPA/edit?tab=t.0#heading=h.1lwhibce68fa) to see what's expected of a team leader.
-- If you want to join a team, reach out to the team leader.
+- **CEO** — Maxime Fournes. Owns organizational strategy, governance, major external relationships, budget, and global operations.
+- **Organizing Director** — Irina Tavera. Owns volunteer growth systems, chapter support, campaign execution, and manages National Directors.
+- **Communications Director** — Jonathan Moody. Owns communication strategy, narrative and messaging, media relations, and content production.
 
-## Onboarding process
+**Board** — Provides governance oversight: strategy approval, annual budget, and major structural changes. The Board does not intervene in day-to-day operations.
 
-1. Sign up as a _volunteer_ (on the [join page](/join) or on Discord). An automated message is sent to the Onboarding team.
-1. Someone from the onboarding team reaches out to the volunteer and invites them for a one-on-one call. They are asked to take actions in an existing local group, set up a local group, or join one of the teams.
+### Chapters
 
-## Educational resources
+PauseAI chapters are local organizations — national, regional, or city-based — that adapt global strategy to their context and run on-the-ground campaigns. Most chapters today are national.
 
-- The PauseAI Basics: [FAQ](/faq), our [proposal](/proposal), [risks](/risks), [x-risk](/xrisk), [urgency](/urgency), [dangerous-capabilities](/dangerous-capabilities), [mitigating pause failures](/mitigating-pause-failures)
-- [Flyering](/flyering): How to flyer effectively
+**Chapter Directors** are paid by PauseAI Global and manage chapters of high strategic importance. **Chapter Leads** are volunteers or are employed by their local chapter. All Chapter Directors and Leads coordinate through monthly meetings and regular check-ins with the Organizing Director.
+
+Chapters typically have their own community, and may have their own website, social media accounts, and legal entity. Check the [communities page](/communities) to find a chapter near you.
+
+### Volunteers
+
+Volunteers are the heart of the movement. At PauseAI Global, volunteers contribute through operational teams:
+
+| Team | Focus |
+|------|-------|
+| **Operations Team** | Internal systems, website, tools, technical infrastructure |
+| **Onboarding Team** | Welcoming new volunteers and getting them active |
+| **Comms Team** | Content support, social media, newsletter |
+
+Each team is owned by a member of the paid staff, and may be led day-to-day by a dedicated volunteer.
+
+If you want to get involved locally — protests, meetups, lobbying — that happens through your [local chapter](/communities).
+
+### Advisory Council
+
+The Advisory Council is a group of experienced, high-contribution volunteers who advise the Executive Team on strategy and raise issues from across the movement. It meets monthly, is invite-based, and operates on a "disagree and commit" principle: members can debate and challenge ideas, but once the Executive Team makes a decision, it is respected.
+
+## How We Work
+
+**Decision documentation:** We follow a principle of "if it's not written down, it doesn't exist." Significant decisions are recorded with what was decided, who decided, when, and why.
+
+**Communication:** [Discord](https://discord.gg/2XXWXvErfA) is our community space for discussion and coordination. Decisions and documentation live in our internal knowledge management system (Notion).
+
+**Campaigns:** PauseAI runs coordinated campaigns across the federation. Campaign themes are set by the Executive Team in consultation with Chapter Directors and Leads. Chapters adapt campaigns to their local context.
+
+## Get Involved
+
+- **[Join PauseAI](/join)** — Sign up as a volunteer. Someone from our onboarding team will reach out to help you find the best way to contribute.
+- **[Find a community near you](/communities)** — Most groups communicate on our [Discord server](https://discord.gg/2XXWXvErfA), and some use WhatsApp or other tools.
+- **[Donate](/donate)** — Support the movement financially.
+- **[Microgrants](/microgrants)** — Apply for funding for your PauseAI-related project or event.
+- **[Vacancies](/vacancies)** — See open positions.
+- **[Google Calendar](https://calendar.google.com/calendar/u/0?cid=Y19mNWE4YWYyMDZlNjM1ODc2NjVjNmU4MzAzOTgzZmVmYWYzYTBjNjE0NGRiMGFhNDljOTcwZWZhNTEwYTNkODY3QGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20)** — PauseAI events calendar.
+- **[Anonymous feedback](https://pauseai.info/contact-us?tab=feedback)** — Share critical thoughts with us while remaining anonymous.
+
+## Educational Resources
+
+- [PauseAI Basics](/faq): FAQ, [our proposal](/proposal), [risks](/risks), [x-risk](/xrisk), [urgency](/urgency), [dangerous capabilities](/dangerous-capabilities)
+- [Flyering guide](/flyering): How to flyer effectively
 - [Counterarguments](/counterarguments)
-- [Organizing a protest](/organizing-a-protest)
+- [Organizing a protest](/protest-guide)
 - [Learn about AI safety](/learn)
 - [PauseAI in the media](/press)
 - [Email builder](/email-builder)
 - [US Lobby guide](/us-lobby-guide)
-- [Writing press releases](/writing-press-releases)
+- [Writing press releases](/press-releases)
 
 ## Strategy
 
 - [Theory of Change](/theory-of-change)
-- [Communication strategy](/communication-strategy): how we write our messages
-- [Roadmap](/roadmap): budget-dependent planning
-- [Values](/values): core values that should guide our decisions
+- [Communication strategy](/communication-strategy): How we write our messages
+- [Roadmap](/roadmap): Budget-dependent planning
+- [Values](/values): Core values that guide our decisions
 
-## Other useful links
+## Tools We Use
 
-- [Free book on AI X-Risk: Uncontrollable](https://impactbooks.store/cart/47288196366640:1?discount=UNCON-P3SFRS)
-- [Google Calendar link](https://calendar.google.com/calendar/u/0?cid=Y19mNWE4YWYyMDZlNjM1ODc2NjVjNmU4MzAzOTgzZmVmYWYzYTBjNjE0NGRiMGFhNDljOTcwZWZhNTEwYTNkODY3QGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20)
-- [Anonymous feedback](https://pauseai.info/contact-us?tab=feedback): If you want to share some critical thoughts with us while remaining anonymous.
-- [Microgrants](/microgrants): If you want funding for your PauseAI related project / event
-
-## Tools used
-
-- [Discord](https://discord.gg/ZuX559xKwf) for internal coordination / chats.
-- [Gmail](https://gmail.com) for `@pauseai.info` email addresses.
-- [Google Suite](https://workspace.google.com/) for documents, spreadsheets, files, folders.
-- [Trello](https://trello.com/) is used by some teams for issue / ToDo tracking. (org name: `pauseaiinfo`)
-- [Figma](https://figma.com) for designing flyers and other graphics. ([template here](https://www.figma.com/design/iQ4PHQTi1vAVmT9Lckazqt/PauseAI-designs---editable)
-- [Airtable](https://airtable.com/) for managing teams, volunteers and responsibilities.
+- [Discord](https://discord.gg/2XXWXvErfA) — Community coordination and chat
+- [Gmail](https://gmail.com) — @pauseai.info email addresses
+- [Google Suite](https://drive.google.com) — Documents, spreadsheets, files
+- [Notion](https://notion.so) — Knowledge management, internal wiki, project management
+- [Airtable](https://airtable.com) — Managing volunteers and responsibilities
 
 ## Social Media
 
-You can find us on [Discord](https://discord.gg/ZuX559xKwf) (this is where most of the coordination happens!), [Twitter](https://twitter.com/PauseAI), [Substack](https://substack.com/@pauseai), [Facebook](https://www.facebook.com/PauseAI), [TikTok](https://www.tiktok.com/@pauseai), [LinkedIn](https://www.linkedin.com/uas/login?session_redirect=/company/97035448/), [YouTube](https://www.youtube.com/@PauseAI), [Instagram](https://www.instagram.com/pause_ai) and [Reddit](https://www.reddit.com/r/PauseAI/).
-You can mail/contact us at [joep@pauseai.info](mailto:joep@pauseai.info).
+Find us on [Discord](https://discord.gg/2XXWXvErfA), [Twitter/X](https://twitter.com/PauseAI), [Substack](https://pauseai.substack.com), [Facebook](https://www.facebook.com/PauseAI), [TikTok](https://www.tiktok.com/@pauseai), [LinkedIn](https://www.linkedin.com/company/pauseai), [YouTube](https://www.youtube.com/@PauseAI), [Instagram](https://www.instagram.com/pause_ai), [Reddit](https://www.reddit.com/r/PauseAI/), and [BlueSky](https://bsky.app/profile/pauseai.info).
 
-## Design resources (flyers, posters, logo)
+[Contact us](/contact-us) for inquiries.
 
-- Figma [community template](https://www.figma.com/design/iQ4PHQTi1vAVmT9Lckazqt/PauseAI-designs---editable)
-- If you want to create PauseAI-related material yourself, you can use our brand color _#FF9416_ and the fonts _Saira Condensed_ (700), _Montserrat Black_ and _Roboto Slab_ (300, 700).
-- [Media Google Drive folder](https://drive.google.com/drive/folders/1bQ_MZ8giK-Mee4ABkO0BgcFInaXruNpa?usp=sharing)
+## Design Resources
+
+[Figma community template](https://www.figma.com/design/iQ4PHQTi1vAVmT9Lckazqt/PauseAI-designs---editable) for creating PauseAI materials. Brand color: **#FF9416**. Fonts: Saira Condensed (700), Montserrat Black, Roboto Slab (300, 700).
+
+[Media Google Drive folder](https://drive.google.com/drive/folders/1bQ_MZ8giK-Mee4ABkO0BgcFInaXruNpa?usp=sharing) for logos, flyers, and posters.

--- a/static/org.svg
+++ b/static/org.svg
@@ -1,0 +1,280 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1000" height="950" viewBox="0 0 1000 950" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="#333" />
+        </marker>
+        <style>
+            @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&amp;display=swap');
+
+            .node-box {
+                fill: #ffffff;
+                stroke: #333;
+                stroke-width: 2;
+            }
+
+            .node-box-staff {
+                fill: #000000;
+                stroke: #333;
+                stroke-width: 2;
+            }
+
+            .group-box {
+                fill: none;
+                stroke: #666;
+                stroke-width: 1.5;
+                stroke-dasharray: 5, 5;
+            }
+
+            .text-title {
+                font-family: 'Inter', sans-serif;
+                font-size: 16px;
+                font-weight: 600;
+                fill: #111;
+                text-anchor: middle;
+            }
+
+            .text-title-light {
+                font-family: 'Inter', sans-serif;
+                font-size: 16px;
+                font-weight: 600;
+                fill: #fff;
+                text-anchor: middle;
+            }
+
+            .text-subtitle {
+                font-family: 'Inter', sans-serif;
+                font-size: 14px;
+                fill: #444;
+                text-anchor: middle;
+            }
+
+            .text-subtitle-light {
+                font-family: 'Inter', sans-serif;
+                font-size: 14px;
+                fill: #ccc;
+                text-anchor: middle;
+            }
+
+            .text-list {
+                font-family: 'Inter', sans-serif;
+                font-size: 12px;
+                fill: #555;
+                text-anchor: start;
+            }
+
+            .text-label {
+                font-family: 'Inter', sans-serif;
+                font-size: 12px;
+                fill: #666;
+                font-style: italic;
+                text-anchor: middle;
+            }
+
+            .connector {
+                fill: none;
+                stroke: #333;
+                stroke-width: 1.5;
+                marker-end: url(#arrowhead);
+            }
+
+            .connector-no-arrow {
+                fill: none;
+                stroke: #333;
+                stroke-width: 1.5;
+            }
+        </style>
+    </defs>
+
+    <!-- Background -->
+    <rect width="1000" height="950" fill="white" rx="8"/>
+
+    <!-- Board (Top) -->
+    <g transform="translate(400, 30)">
+        <rect x="0" y="0" width="260" height="140" rx="4" class="node-box" />
+        <text x="130" y="30" class="text-title">BOARD</text>
+        <line x1="20" y1="50" x2="240" y2="50" stroke="#ddd" />
+
+        <circle cx="30" cy="70" r="2" fill="#555" />
+        <text x="40" y="75" class="text-list">Joep Meinderstma (President)</text>
+
+        <circle cx="30" cy="90" r="2" fill="#555" />
+        <text x="40" y="95" class="text-list">Michiel Van den Ingh (Treasurer)</text>
+
+        <circle cx="30" cy="110" r="2" fill="#555" />
+        <text x="40" y="115" class="text-list">Otto Barten</text>
+    </g>
+
+    <!-- Advisory Council (Left) -->
+    <g transform="translate(50, 250)">
+        <rect x="0" y="0" width="160" height="180" rx="4" class="node-box" />
+        <text x="80" y="30" class="text-title">Advisory Council</text>
+        <line x1="20" y1="50" x2="140" y2="50" stroke="#ddd" />
+        <circle cx="30" cy="70" r="2" fill="#555" />
+        <line x1="40" y1="70" x2="130" y2="70" stroke="#eee" />
+        <circle cx="30" cy="90" r="2" fill="#555" />
+        <line x1="40" y1="90" x2="130" y2="90" stroke="#eee" />
+        <circle cx="30" cy="110" r="2" fill="#555" />
+        <line x1="40" y1="110" x2="130" y2="110" stroke="#eee" />
+        <circle cx="30" cy="130" r="2" fill="#555" />
+        <line x1="40" y1="130" x2="130" y2="130" stroke="#eee" />
+    </g>
+
+    <!-- Exec Team Container -->
+    <g transform="translate(280, 220)">
+        <rect x="0" y="0" width="500" height="240" rx="4" class="group-box" />
+        <rect x="15" y="-10" width="100" height="20" fill="white" />
+        <text x="20" y="5" class="text-title" style="text-anchor: start;">EXEC TEAM</text>
+
+        <!-- CEO -->
+        <g transform="translate(150, 20)">
+            <rect x="0" y="0" width="200" height="70" rx="4" class="node-box-staff" />
+            <text x="100" y="30" class="text-title-light">CEO</text>
+            <text x="100" y="55" class="text-subtitle-light">Maxime Fournes</text>
+        </g>
+
+        <!-- Org Director -->
+        <g transform="translate(30, 140)">
+            <rect x="0" y="0" width="160" height="70" rx="4" class="node-box-staff" />
+            <text x="80" y="30" class="text-title-light">Org Director</text>
+            <text x="80" y="55" class="text-subtitle-light">Irina Tavera</text>
+        </g>
+
+        <!-- Comms Director -->
+        <g transform="translate(310, 140)">
+            <rect x="0" y="0" width="160" height="70" rx="4" class="node-box-staff" />
+            <text x="80" y="30" class="text-title-light">Comms Director</text>
+            <text x="80" y="55" class="text-subtitle-light">Jonathan Moody</text>
+        </g>
+    </g>
+
+
+    <!-- Sub-Teams -->
+    <!-- Onboarding -->
+    <g transform="translate(300, 520)">
+        <rect x="0" y="0" width="130" height="80" rx="4" class="node-box" />
+        <text x="65" y="25" class="text-title" style="font-size: 14px;">ONBOARDING</text>
+        <circle cx="20" cy="45" r="2" fill="#555" />
+        <line x1="30" y1="45" x2="110" y2="45" stroke="#eee" />
+        <circle cx="20" cy="65" r="2" fill="#555" />
+        <line x1="30" y1="65" x2="110" y2="65" stroke="#eee" />
+    </g>
+
+    <!-- Ops Team -->
+    <g transform="translate(460, 520)">
+        <rect x="0" y="0" width="130" height="80" rx="4" class="node-box" />
+        <text x="65" y="25" class="text-title" style="font-size: 14px;">OPERATIONS</text>
+        <circle cx="20" cy="45" r="2" fill="#555" />
+        <line x1="30" y1="45" x2="110" y2="45" stroke="#eee" />
+        <circle cx="20" cy="65" r="2" fill="#555" />
+        <line x1="30" y1="65" x2="110" y2="65" stroke="#eee" />
+    </g>
+
+    <!-- Comms Team -->
+    <g transform="translate(620, 520)">
+        <rect x="0" y="0" width="130" height="80" rx="4" class="node-box" />
+        <text x="65" y="25" class="text-title" style="font-size: 14px;">COMMS</text>
+        <circle cx="20" cy="45" r="2" fill="#555" />
+        <line x1="30" y1="45" x2="110" y2="45" stroke="#eee" />
+        <circle cx="20" cy="65" r="2" fill="#555" />
+        <line x1="30" y1="65" x2="110" y2="65" stroke="#eee" />
+    </g>
+
+    <rect x="280" y="490" width="500" height="150" rx="4" class="group-box" />
+    <rect x="295" y="630" width="160" height="20" fill="white" />
+    <text x="300" y="645" class="text-title" style="text-anchor: start;">VOLUNTEER TEAMS</text>
+
+
+    <!-- Chapter Leadership -->
+    <g transform="translate(280, 680)">
+        <rect x="0" y="0" width="500" height="180" rx="4" class="group-box" />
+        <rect x="15" y="-10" width="180" height="20" fill="white" />
+        <text x="20" y="5" class="text-title" style="text-anchor: start;">CHAPTER LEADERSHIP</text>
+
+        <!-- National Directors -->
+        <g transform="translate(30, 30)">
+            <rect x="0" y="0" width="220" height="120" rx="4" class="node-box-staff" />
+            <text x="110" y="30" class="text-title-light" style="font-size: 14px;">National Directors</text>
+
+            <text x="20" y="60" class="text-list" style="fill: #eee;">🇫🇷 Clemence Peyrot</text>
+            <text x="20" y="80" class="text-list" style="fill: #eee;">🇬🇧 Joseph Miller</text>
+            <text x="20" y="100" class="text-list" style="fill: #eee;">🇬🇧 Matilda da Rui (Deputy)</text>
+        </g>
+
+        <!-- Chapter Leads -->
+        <g transform="translate(270, 30)">
+            <rect x="0" y="0" width="180" height="120" rx="4" class="node-box" />
+            <text x="90" y="30" class="text-title" style="font-size: 14px;">Chapter Leads</text>
+            <circle cx="30" cy="60" r="2" fill="#555" />
+            <line x1="40" y1="60" x2="150" y2="60" stroke="#eee" />
+            <circle cx="30" cy="80" r="2" fill="#555" />
+            <line x1="40" y1="80" x2="150" y2="80" stroke="#eee" />
+            <circle cx="30" cy="100" r="2" fill="#555" />
+            <line x1="40" y1="100" x2="150" y2="100" stroke="#eee" />
+        </g>
+    </g>
+
+
+    <!-- CONNECTIONS -->
+
+    <!-- AC -> Board (escalates) -->
+    <path d="M 130 250 L 130 90 L 400 90" class="connector" />
+    <text x="275" y="85" class="text-label" style="text-anchor: middle;">escalates</text>
+
+    <!-- AC -> Exec (advises) -->
+    <path d="M 210 340 L 280 340" class="connector" />
+    <text x="245" y="335" class="text-label">advises</text>
+
+    <!-- Org Director -> AC (runs) -->
+    <path d="M 310 395 L 210 395" class="connector" />
+    <text x="260" y="390" class="text-label">runs</text>
+
+    <!-- CEO > Board (reports to) -->
+    <path d="M 530 240 L 530 170" class="connector" />
+    <rect x="495" y="195" width="70" height="15" fill="white" />
+    <text x="530" y="205" class="text-label" dy="0" style="text-anchor: middle;">reports to</text>
+
+    <!-- CEO > Org Director (manager) -->
+    <path d="M 530 310 L 530 330 L 390 330 L 390 360" class="connector" />
+    <text x="440" y="325" class="text-label">manages</text>
+
+    <!-- CEO > Comms Director (manager) -->
+    <path d="M 530 310 L 530 330 L 670 330 L 670 360" class="connector" />
+    <text x="620" y="325" class="text-label">manages</text>
+
+    <!-- CEO > Ops Team (owns) -->
+    <path d="M 530 310 L 530 520" class="connector" />
+    <rect x="510" y="440" width="40" height="20" fill="white" stroke="none" />
+    <text x="530" y="455" class="text-label">owns</text>
+
+    <!-- Org Director > Onboarding (owns) -->
+    <path d="M 390 430 L 365 520" class="connector" />
+    <rect x="355" y="470" width="40" height="20" fill="white" stroke="none" />
+    <text x="375" y="485" class="text-label">owns</text>
+
+    <!-- Comms Director > Comms Team (owns) -->
+    <path d="M 670 430 L 685 520" class="connector" />
+    <rect x="660" y="470" width="40" height="20" fill="white" stroke="none" />
+    <text x="680" y="485" class="text-label">owns</text>
+
+    <!-- Org Director -> Chapter Leadership (manages and coordinates) -->
+    <path d="M 310 395 L 250 395 L 250 770 L 280 770" class="connector" />
+    <text x="255" y="620" class="text-label" transform="rotate(-90 245 620)">manages and coordinates</text>
+
+    <!-- Comms Director -> Chapter Leadership (aligns communication) -->
+    <path d="M 750 395 L 810 395 L 810 770 L 780 770" class="connector" />
+    <text x="805" y="620" class="text-label" transform="rotate(90 815 620)">aligns communication</text>
+
+
+    <!-- LEGEND -->
+    <g transform="translate(420, 890)">
+        <rect x="0" y="0" width="20" height="20" rx="4" class="node-box-staff" />
+        <text x="30" y="15" class="text-list" style="font-size: 14px;">Staff</text>
+
+        <rect x="80" y="0" width="20" height="20" rx="4" class="node-box" />
+        <text x="110" y="15" class="text-list" style="font-size: 14px;">Volunteers</text>
+    </g>
+
+    <!-- Version -->
+    <text x="20" y="940" style="font-family: 'Inter', sans-serif; font-size: 10px; fill: #333; text-anchor: start;">PauseAI OrgChart v1.1</text>
+</svg>


### PR DESCRIPTION
## Summary

This PR updates the organization page with the new 2026 governance structure.

### Changes

- **Leadership section**: Added Executive Team (CEO, Organizing Director, Communications Director) and Board description
- **Chapters section**: Clarified the role of Chapter Directors vs Chapter Leads
- **Volunteers section**: Replaced Teams page reference with a clear table of operational teams (Operations, Onboarding, Comms)
- **Advisory Council section**: New section describing the advisory council and its operating principles
- **How We Work section**: New section on decision documentation, communication tools, and campaign coordination
- **Get Involved section**: Streamlined calls-to-action
- **Updated org chart**: Replaced PNG with new SVG org chart

### Files changed
- `src/posts/organization.md` - Complete content revamp
- `static/org.svg` - New org chart graphic