### PR TITLE
Add Operations Team page, refactor join listing

### DIFF
--- a/src/posts/join-operations.md
+++ b/src/posts/join-operations.md
@@ -1,0 +1,44 @@
+---
+title: Join the Operations Team
+description: How to get involved with PauseAI's operations team — website, tooling, and technology.
+---
+
+## What we do
+
+We build and maintain the PauseAI website and other parts of our technology stack (tooling etc.), and advise other teams on technology choices. We have [unusual scaling requirements](https://tinyurl.com/pauseaitechandscaling), and we buy rather than build in most cases.
+
+The main website is mostly static, using SvelteKit with clientside hydration, Node, and Markdown, deployed through Netlify.
+
+Yes, we are happy to use language models to accelerate our development.
+
+## Get started
+
+Browse our code and open issues on [GitHub](https://github.com/PauseAI).
+
+The best way to get an idea of what any team does is to read recent messages in their Discord channel. To unlock [#operations-team](https://discord.com/channels/1100491867675709580/1222902730083799120):
+
+1. Fill in the [join form](/join) — make sure you read and confirm the volunteer agreement. This grants you the volunteer role on Discord.
+2. Visit the [pinned post in #volunteers](https://discord.com/channels/1100491867675709580/1185555491024273489/1288188514701148174) and click the button to grant yourself the "view team channels" role.
+3. Join [#operations-team](https://discord.com/channels/1100491867675709580/1222902730083799120).
+
+If you can't see #volunteers, you don't have the volunteer role on Discord yet. You can either fill in the [join form](/join) again (making sure to confirm the volunteer agreement this time), or ask whoever onboarded you to set the role for you.
+
+## Get in touch
+
+- **Book a chat** with our current operations lead: [antb.me/meet](http://antb.me/meet)
+- **Come to a meeting** — Wednesdays 5-6pm UTC on [Google Meet](https://meet.google.com/nxa-rwko-sog)
+
+If you already have a CV, LinkedIn, or website that tells us something about your experience, by all means link it — but don't feel like you need to write one.
+
+## What helps
+
+Any of these can be learned — none are blockers to signing up:
+
+- Web development (SvelteKit, Node, Markdown)
+- Self-directed and able to work asynchronously
+- Bias for action and ideas — we validate choices in review
+- Previous experience with open source development helps — all the usual challenges are amplified in a volunteer org context
+
+## Volunteer details
+
+- Active team members typically contribute 2-5 hours per week, but we welcome one-off bug fixes and sporadic contributions too — no minimum commitment required.

--- a/src/posts/join.md
+++ b/src/posts/join.md
@@ -152,22 +152,17 @@ Interested? [Email Irina](mailto:irina@pauseai.info)
 
 Interested? [Email Irina](mailto:irina@pauseai.info)
 
-### Software Team member
+### Operations Team member
 
-- Duration: 3 months
-- Time Commitment: 2-5 hours per week
+- Time Commitment: No minimum — one-off bug fixes are welcome. Active members typically contribute 2-5 hours per week.
 - Responsibilities:
-  - Build and maintain features for the PauseAI website and other parts of our technology stack (tooling etc.)
-  - Advise and assist other teams on technology choices. We have [unusual scaling requirements](https://tinyurl.com/pauseaitechandscaling), and we buy rather than build in most cases.
+  - Build and maintain the PauseAI website and other technology.
 
 - Key Skills:
-  - (Any of these can be learned: none are blockers to signing up.)
-  - Web development (the main website is mostly static, using SvelteKit with clientside hydration, Node, Markdown, deployed through Netlify).
-  - Self-directed and able to work asynchronously. Bias for action and ideas - we'll validate choices in review. All the usual challenges of open source development are amplified in a volunteer org context - previous experience in those helps.
+  - Web development (SvelteKit, Node, Markdown)
+  - Self-directed and able to work asynchronously
 
-Yes we are happy to use language models to accelerate our development.
-
-Interested? [Email Anthony](mailto:mail@anthonybailey.net) (or DM anthonybailey.net on [Discord](https://discord.gg/2XXWXvErfA). Make sure you've signed the volunteer agreement!
+Read more and find out how to get involved on the [Operations Team page](/join-operations).
 
 ## Stay Updated
 


### PR DESCRIPTION
## Summary

- New `/join-operations` page with detailed info for prospective operations team volunteers: what the team does, how to unlock the Discord channel, meeting details, key skills, and contribution expectations.
- Rename "Software Team" to "Operations Team" on `/join` and replace the detailed listing with a summary linking to the new page.
- Remove 3-month minimum duration commitment from the operations listing.

## Test plan

- [ ] Verify `/join-operations` renders correctly
- [ ] Verify `/join` Operations Team section links to the new page
- [ ] Check Discord links open correctly (server, pinned post, channel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)