### PR TITLE
fix: banner image CSS not applied

### DIFF
--- a/src/routes/[slug]/+page.svelte
+++ b/src/routes/[slug]/+page.svelte
@@ -55,7 +55,7 @@
 		overflow: hidden;
 	}
 
-	.banner img {
+	.banner :global(img) {
 		width: 100%;
 		max-height: 400px;
 		object-fit: cover;


### PR DESCRIPTION
## Summary
- The `.banner img` CSS selector was broken since 83063f41, which replaced `<img>` with the `<Image>` Svelte component
- Svelte's scoped CSS can't pierce component boundaries, so `width: 100%`, `max-height: 400px`, `object-fit: cover`, and `display: block` were not being applied to the banner image
- Fixed by using `.banner :global(img)` which scopes the `.banner` part but lets `img` match across component boundaries

See #659 for follow-up issues around banner image duplication and cropping of square images.

## Test plan
- [ ] Visit a post with a banner image (e.g. `/if-anyone-builds-it-campaign`) and verify the image fills the container width and is capped at 400px height

## Screenshots

| Page | Before | After |
|------|--------|-------|
| `/4-levels-of-ai-regulation` | <img width="400" alt="before" src="https://github.com/user-attachments/assets/bda0cbad-94f6-4697-b613-cdededd4d85e" /> | <img width="400" alt="after" src="https://github.com/user-attachments/assets/303075fe-c4f4-4469-9536-9b8d8ac2724c" /> |
| `/if-anyone-builds-it-campaign` | <img width="400" alt="before" src="https://github.com/user-attachments/assets/e7650ade-75b2-41ee-b45b-21e81be7e145" /> | <img width="400" alt="after" src="https://github.com/user-attachments/assets/f9b05837-235a-4659-b3d9-ca6f8ddabe01" /> |
| `/india-summit-2026` | <img width="400" alt="before" src="https://github.com/user-attachments/assets/355dcf12-4898-4812-ad08-a69b86b06837" /> | <img width="400" alt="after" src="https://github.com/user-attachments/assets/1ef588a4-3190-4989-a8a9-720cd5c7af1d" /> |

Note: rows 1 and 3 show cropping in the "after" column due to `object-fit: cover` on square images — this is tracked in #659. This PR restores the banner styling to the state it was in before 83063f41 broke it.