### PR TITLE
Refactor hero/nav layout to use standard positioning

### DIFF
--- a/src/lib/components/navbar/Navbar.svelte
+++ b/src/lib/components/navbar/Navbar.svelte
@@ -3,16 +3,15 @@
 	import NarrowNavbar from './narrow/NarrowNavbar.svelte'
 
 	export let inverted = false
-	export let moveUp = false
 </script>
 
 <div class="wide-navbar">
-	<WideNavbar {inverted} {moveUp}>
+	<WideNavbar {inverted}>
 		<slot />
 	</WideNavbar>
 </div>
 <div class="narrow-navbar">
-	<NarrowNavbar {inverted} {moveUp}>
+	<NarrowNavbar {inverted}>
 		<slot />
 	</NarrowNavbar>
 </div>

--- a/src/lib/components/navbar/universal/UniversalNavbar.svelte
+++ b/src/lib/components/navbar/universal/UniversalNavbar.svelte
@@ -7,7 +7,6 @@
 	import { onMount } from 'svelte'
 
 	export let inverted = false
-	export let moveUp = false
 
 	$: logo_animate = localizeHref($page.url.pathname) != '/'
 
@@ -18,7 +17,7 @@
 	})
 </script>
 
-<nav class:inverted-header={inverted} class:move-up={moveUp} bind:this={nav}>
+<nav class:inverted-header={inverted} bind:this={nav}>
 	<div class="logo-container">
 		<div class="compensate-min-space-between" />
 		<div class="compensate-offset" />
@@ -67,14 +66,6 @@
 		flex-wrap: wrap;
 		container-type: inline-size;
 		padding: var(--vspace) 0;
-	}
-
-	nav.move-up {
-		position: absolute;
-		top: 0;
-		left: 0;
-		right: 0;
-		z-index: 1;
 	}
 
 	nav > * {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -106,7 +106,7 @@
 	{#if hero}
 		<div class="hero-section">
 			<Hero />
-			<Header inverted moveUp />
+			<Header inverted />
 		</div>
 	{:else}
 		<Header />
@@ -149,6 +149,14 @@
 
 	.hero-section {
 		position: relative;
+	}
+
+	.hero-section :global(nav) {
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		z-index: 1;
 	}
 
 	.layout {

--- a/src/routes/header.svelte
+++ b/src/routes/header.svelte
@@ -9,10 +9,9 @@
 	const enableBot = false
 
 	export let inverted = false
-	export let moveUp = false
 </script>
 
-<Navbar {inverted} {moveUp}>
+<Navbar {inverted}>
 	<Navlink {inverted} first href="/learn">{m.header_learn()}</Navlink>
 	<Navlink {inverted} href="/proposal">{m.header_proposal()}</Navlink>
 	<Navlink {inverted} href="/communities">{m.header_events()}</Navlink>


### PR DESCRIPTION
Fixes #563.

## What changed

Replaces the negative-margin + `height: 0` hack used to overlay the nav on the homepage hero with standard CSS positioning:
- **`+layout.svelte`**: When the hero is shown, `<Hero>` and `<Header>` are wrapped in a `<div class="hero-section">` (`position: relative`). A CSS rule positions any `<nav>` inside it absolutely at the top. On all other pages, `<Header>` renders in normal flow as before.
- **`UniversalNavbar.svelte`**: The `move-up` class and its CSS rule are removed, along with the `moveUp` boolean prop from the entire component chain (`header.svelte` → `Navbar.svelte` → `UniversalNavbar.svelte`). The `.hero-section :global(nav)` rule in `+layout.svelte` now handles the positioning instead.

## Why

The old approach was a non-obvious hack: the nav was pulled up by `-100vh` and given `height: 0` so it wouldn't affect layout. `position: absolute` expresses the same intent directly. The refactor also makes `z-index: 1` on the nav reliable (z-index requires a positioned element), and removes `moveUp`, a boolean prop that threaded through five components only to add a CSS class.

## What it doesn't change

Visual output is identical to `main` for the current nav.