### PR TITLE
Homepage hero: fix SSR hydration flash and portrait desktop layout

### DIFF
--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -61,12 +61,6 @@
 		text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
 	}
 
-	.hero :global(picture) {
-		display: block;
-		width: 100%;
-		height: 100%;
-	}
-
 	.hero :global(img) {
 		width: 100%;
 		height: 100%;


### PR DESCRIPTION
Closes #668

## Summary

Fixes two issues with the homepage hero section's image selection and layout logic.

- **Replaces JS-based image switching** (`isMobile` + resize listener) with a native `<picture>` + `<source media>` element, so the browser picks the correct image before any JS runs — eliminating the SSR hydration flash on mobile
- **Fixes mobile breakpoint condition** from `(max-width: 850px), (orientation: portrait)` (OR) to `(max-width: 850px)` (width only), so large portrait windows on desktop (e.g. a half-screen 4K monitor) no longer incorrectly get the mobile layout
- Updates the desktop `scale(0.95)` media query to the complement: `(min-width: 851px)`

Note: landscape mobile did not look great before this PR either — this is a pre-existing limitation, not a regression.

## Screenshots

### Vertical window on desktop

| Before | After |
|--------|-------|
| <img width="1263" alt="Before - vertical desktop" src="https://github.com/user-attachments/assets/7bf1b030-8a34-4f6d-81fa-6bbcdaf56548" /> | <img width="1263" alt="After - vertical desktop" src="https://github.com/user-attachments/assets/500613b2-0cf1-46a6-8694-b20e09c0e869" /> |

### Landscape mobile (known limitation)

<img width="400" alt="Landscape mobile" src="https://github.com/user-attachments/assets/f262941a-0b83-49e3-b92a-c17e7181e09c" />

## Test plan

- [ ] On mobile portrait: mobile image shown, no flash on load
- [ ] On desktop landscape: desktop image shown with scale(0.95)
- [ ] On a wide portrait window (e.g. half-screen 4K): desktop layout used, not mobile