### PR TITLE
fix: make quotes on homepage clickable to their sources

### DIFF
--- a/src/lib/components/QuoteContent.svelte
+++ b/src/lib/components/QuoteContent.svelte
@@ -4,7 +4,13 @@
 	export let quote: CarouselQuote
 </script>
 
-<div class="quote-card">
+<svelte:element
+	this={quote.href ? 'a' : 'div'}
+	class="quote-card"
+	href={quote.href}
+	target={quote.href ? '_blank' : undefined}
+	rel={quote.href ? 'noopener noreferrer' : undefined}
+>
 	<div class="quote-text">
 		{quote.text}
 	</div>
@@ -23,7 +29,7 @@
 			<p class="author-title">{quote.title}</p>
 		</div>
 	</div>
-</div>
+</svelte:element>
 
 <style>
 	.quote-card {
@@ -32,6 +38,8 @@
 		display: flex;
 		flex-direction: column;
 		justify-content: space-between;
+		color: inherit;
+		text-decoration: none;
 	}
 
 	.quote-text {

--- a/src/lib/components/QuotesCarousel.svelte
+++ b/src/lib/components/QuotesCarousel.svelte
@@ -33,13 +33,15 @@
 			text: m.home_quotes_asi_statement_text(),
 			author: m.home_quotes_asi_statement_author(),
 			title: m.home_quotes_asi_statement_title(),
-			image: ASI_Statement
+			image: ASI_Statement,
+			href: 'https://superintelligence-statement.org/'
 		},
 		{
 			text: m.home_quotes_cais_text(),
 			author: m.home_quotes_cais_author(),
 			title: m.home_quotes_cais_title(),
-			image: CAIS
+			image: CAIS,
+			href: 'https://www.theguardian.com/technology/2023/may/30/risk-of-extinction-by-ai-should-be-global-priority-say-tech-experts'
 		},
 		{
 			text: m.home_quotes_hinton_text(),
@@ -51,7 +53,8 @@
 			text: m.home_quotes_hawking_text(),
 			author: 'Stephen Hawking',
 			title: m.home_quotes_hawking_title(),
-			image: Hawking
+			image: Hawking,
+			href: 'https://www.bbc.com/news/technology-30290540'
 		},
 		{
 			text: m.home_quotes_turing_text(),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -113,4 +113,5 @@ export type CarouselQuote = {
 	author: string
 	title: string
 	image: Picture
+	href?: string
 }


### PR DESCRIPTION
Closes #681

## Summary

- Adds an optional `href` field to the `CarouselQuote` type
- Wraps quote cards in an `<a>` tag when a source URL is available, otherwise renders as a plain `<div>` (no behaviour change for quotes without a source)
- Adds source URLs for ASI Statement, CAIS Statement, and Stephen Hawking quotes (sourced from existing `data.json`)
- Styles the link to inherit colour and remove underline so the card appearance is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)