### PR TITLE
Fix Theme Flashing on Page Load

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -22,6 +22,7 @@ declare global {
 	interface Window {
 		twttr?: Twttr
 		selectBanners(): void
+		applyTheme(): void
 	}
 
 	declare module '*.md' {

--- a/src/app.html
+++ b/src/app.html
@@ -6,10 +6,6 @@
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		<link rel="alternate" type="application/atom+xml" href="/rss.xml" />
 
-		<script type="module">
-			document.documentElement.setAttribute('color-scheme', 'dark')
-		</script>
-
 		<!-- Google Tag Manager -->
 		<script>
 			;(function (w, d, s, l, i) {

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -9,7 +9,9 @@ const userThemeKey = 'user-theme'
 const prefersDark =
 	typeof matchMedia === 'undefined' ? false : matchMedia('(prefers-color-scheme: dark)').matches
 
-const initialUserTheme = (browser ? localStorage.getItem(userThemeKey) : 'auto') as UserTheme
+const initialUserTheme = (
+	browser ? localStorage.getItem(userThemeKey) || 'auto' : 'auto'
+) as UserTheme
 const initialTheme =
 	initialUserTheme === 'auto' ? (prefersDark ? 'dark' : 'light') : initialUserTheme
 

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,4 +1,4 @@
-import { writable } from 'svelte/store'
+import { writable, get } from 'svelte/store'
 import { browser } from '$app/environment'
 
 /** What's being rendered */
@@ -6,14 +6,16 @@ type Theme = 'light' | 'dark'
 /** User selected status, defaults to `auto` */
 type UserTheme = Theme | 'auto'
 const userThemeKey = 'user-theme'
-const prefersDark =
-	typeof matchMedia === 'undefined' ? false : matchMedia('(prefers-color-scheme: dark)').matches
+
+const getSystemTheme = () =>
+	typeof matchMedia !== 'undefined' && matchMedia('(prefers-color-scheme: dark)').matches
+		? 'dark'
+		: 'light'
 
 const initialUserTheme = (
 	browser ? localStorage.getItem(userThemeKey) || 'auto' : 'auto'
 ) as UserTheme
-const initialTheme =
-	initialUserTheme === 'auto' ? (prefersDark ? 'dark' : 'light') : initialUserTheme
+const initialTheme = initialUserTheme === 'auto' ? getSystemTheme() : initialUserTheme
 
 export const theme = writable<Theme>(initialTheme)
 export const userTheme = writable<UserTheme>(initialUserTheme)
@@ -22,16 +24,14 @@ if (typeof matchMedia !== 'undefined') {
 	matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (event) => {
 		const newColorScheme = event.matches ? 'dark' : 'light'
 		// Only update if user is on auto
-		userTheme.subscribe((value) => {
-			if (value === 'auto') {
-				theme.set(newColorScheme)
-			}
-		})()
+		if (get(userTheme) === 'auto') {
+			theme.set(newColorScheme)
+		}
 	})
 }
 
 userTheme.subscribe((value) => {
-	theme.set(value === 'auto' ? (prefersDark ? 'dark' : 'light') : value)
+	theme.set(value === 'auto' ? getSystemTheme() : value)
 })
 
 theme.subscribe((value) => {

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -11,7 +11,7 @@ const prefersDark =
 
 const initialUserTheme = (browser ? localStorage.getItem(userThemeKey) : 'auto') as UserTheme
 const initialTheme =
-	initialUserTheme === 'auto' ? (prefersDark ? 'dark' : 'light') : (initialUserTheme as Theme)
+	initialUserTheme === 'auto' ? (prefersDark ? 'dark' : 'light') : initialUserTheme
 
 export const theme = writable<Theme>(initialTheme)
 export const userTheme = writable<UserTheme>(initialUserTheme)

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -9,19 +9,24 @@ const userThemeKey = 'user-theme'
 const prefersDark =
 	typeof matchMedia === 'undefined' ? false : matchMedia('(prefers-color-scheme: dark)').matches
 
+const initialUserTheme = (browser ? localStorage.getItem(userThemeKey) : 'auto') as UserTheme
+const initialTheme =
+	initialUserTheme === 'auto' ? (prefersDark ? 'dark' : 'light') : (initialUserTheme as Theme)
+
+export const theme = writable<Theme>(initialTheme)
+export const userTheme = writable<UserTheme>(initialUserTheme)
+
 if (typeof matchMedia !== 'undefined') {
 	matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (event) => {
 		const newColorScheme = event.matches ? 'dark' : 'light'
-		if (userTheme.subscribe((value) => value === 'auto')) {
-			theme.set(newColorScheme)
-		}
+		// Only update if user is on auto
+		userTheme.subscribe((value) => {
+			if (value === 'auto') {
+				theme.set(newColorScheme)
+			}
+		})()
 	})
 }
-
-export const theme = writable<Theme>('light')
-export const userTheme = writable<UserTheme>(
-	browser ? (localStorage.getItem(userThemeKey) as UserTheme) || 'auto' : 'auto'
-)
 
 userTheme.subscribe((value) => {
 	theme.set(value === 'auto' ? (prefersDark ? 'dark' : 'light') : value)

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -26,6 +26,7 @@
 	import Header from './header.svelte'
 	import PageTransition from './transition.svelte'
 	import bannerSelection from './banner-selection.js?raw'
+	import themeSelection from './theme-selection.js?raw'
 	import type { PageData } from './$types'
 
 	export let data: PageData
@@ -70,6 +71,13 @@
 	$: if (browser && eventFound) {
 		delete document.documentElement.dataset.activeBanner
 	}
+
+	function sanitizeScript(code: string) {
+		return code
+			.replaceAll(/\/\*[\s\S]*?\*\//g, '') // remove block comments
+			.replaceAll(/\/\/[^"'`\n]*?$/gm, '') // remove line comments
+			.replaceAll(/\n\s*(?=\n)/g, '') // remove empty lines
+	}
 </script>
 
 <svelte:head>
@@ -101,12 +109,10 @@
 	</script>
 
 	<!-- eslint-disable-next-line svelte/no-at-html-tags not vulnerable against XSS -->
-	{@html `<${'script'}>${
-		bannerSelection
-			.replaceAll(/\/\*[\s\S]*?\*\//g, '') // remove block comments
-			.replaceAll(/\/\/[^"'`\n]*?$/gm, '') // remove line comments
-			.replaceAll(/\n\s*(?=\n)/g, '') // remove empty lines
-	}</script>`}
+	{@html `<${'script'}>${sanitizeScript(themeSelection)}</script>`}
+
+	<!-- eslint-disable-next-line svelte/no-at-html-tags not vulnerable against XSS -->
+	{@html `<${'script'}>${sanitizeScript(bannerSelection)}</script>`}
 </svelte:head>
 
 <PreloadFonts urls={[robotoSlabLatin300, sairaCondensedLatin700]} />

--- a/src/routes/banner-selection.js
+++ b/src/routes/banner-selection.js
@@ -3,9 +3,6 @@
 // data-is-active-banner-geo, and data-active-campaign-banner on <html>.
 // Exposed as window.selectBanners to allow re-runs.
 
-// eslint-disable-next-line @typescript-eslint/triple-slash-reference
-/// <reference path="../app.d.ts" />
-
 /**
  * @typedef {Object} BannerRule
  * @property {string} id

--- a/src/routes/theme-selection.js
+++ b/src/routes/theme-selection.js
@@ -1,0 +1,23 @@
+// Theme selection: picks the active theme before first paint.
+// Reads user-theme from localStorage, checks system preference, and sets color-scheme on <html>.
+// Exposed as window.applyTheme to allow re-runs.
+
+;(function () {
+	var userThemeKey = 'user-theme'
+
+	window.applyTheme = function () {
+		var userTheme = 'auto'
+		try {
+			userTheme = localStorage.getItem(userThemeKey) || 'auto'
+		} catch (e) {
+			// localStorage might be unavailable
+		}
+
+		var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+		var theme = userTheme === 'auto' ? (prefersDark ? 'dark' : 'light') : userTheme
+
+		document.documentElement.setAttribute('color-scheme', theme)
+	}
+
+	window.applyTheme()
+})()

--- a/src/routes/theme-selection.js
+++ b/src/routes/theme-selection.js
@@ -9,7 +9,7 @@
 		var userTheme = 'auto'
 		try {
 			userTheme = localStorage.getItem(userThemeKey) || 'auto'
-		} catch (e) {
+		} catch {
 			// localStorage might be unavailable
 		}
 


### PR DESCRIPTION
## Summary
This PR fixes the "wrong theme flashing" issue where the site would briefly show a default theme (often dark) before switching to the user's preferred theme during hydration.

## Key Changes
- **Blocking Theme Selection**: Created a raw JS script `src/routes/theme-selection.js` that runs early in the `<head>`. This is the core fix to prevent flashing by applying the correct `color-scheme` attribute before the first paint.
- **Removed Default Placeholder**: Removed a hardcoded `<script type="module">` in `src/app.html`.
- **Deduplicated Script Injection**: Refactored `src/routes/+layout.svelte` to use a `sanitizeScript` helper function, deduplicating the logic for minifying and injecting both the theme and banner selection scripts.
- **Theme Logic Refactoring**: Refactored `src/lib/theme.ts` to improve reactivity and consistency. It now uses a centralized `getSystemTheme()` helper and cleaner store access (using `get()`) within the media query listener, ensuring the active theme stays in sync with system changes when the user preference is set to 'auto'.
- **TypeScript Support**: Added `window.applyTheme` to `src/app.d.ts`.

## Rationale
The flashing was more noticeable than previously thought, especially for users with a light theme preference on a slow connection. Moving this logic to a blocking inline script in the layout head ensures the visual state is settled before the first paint.

## Verification
- Checked theme application with both `localStorage` settings and system preferences.
- Verified that toggling through the UI still works correctly and persists.
- Confirmed that the `color-scheme` attribute is set immediately upon page load.
