### PR TITLE
Update privacy policy with GDPR-aligned rewrite

### DIFF
--- a/src/posts/privacy.md
+++ b/src/posts/privacy.md
@@ -2,71 +2,77 @@
 title: PauseAI Privacy Policy
 ---
 
-**Effective Date:** July 17th, 2024
+**Effective Date:** April 17th, 2026
 
 ## 1. Introduction
 
-Welcome to PauseAI!
-We are committed to protecting your privacy and ensuring that your personal information is handled in a safe and responsible manner.
-This Privacy Policy outlines how [Stichting PauseAI](/legal) ("we," "us," "our") collects, uses, discloses, and protects your personal information in accordance with NL / EU law.
+Welcome to PauseAI! We are committed to protecting your privacy and handling your personal information in a safe, transparent, and responsible manner.
+
+This Privacy Policy explains how [Stichting PauseAI](/legal) ("we," "us," "our") collects, uses, shares, and protects your personal data in accordance with the European General Data Protection Regulation (GDPR) and Dutch privacy law.
+
+**Stichting PauseAI details:**
+
+- **Email:** [maxime@pauseai.info](mailto:maxime@pauseai.info)
+- **Address:** [Insert physical address of Stichting PauseAI]
+- **KVK Number:** [Insert Chamber of Commerce number]
 
 ## 2. Information We Collect
 
-### a. Personal Information
+We only collect information that we need to organize our volunteer network and improve our services.
 
-- When you [join](/join) as a member, we collect your name, email address, and any other information you provide during registration.
+- **Personal Information:** When you fill out our [join form](/join), we collect your name, email address, country of residence, and any other details or skills you choose to share with us.
+- **Usage Information:** We use Google Analytics to understand how visitors interact with our website. This includes data on the pages you visit and the time spent on them.
 
-### b. Usage Information
+## 3. How and Why We Use Your Information
 
-- We use Google Analytics to track and analyze visitor interactions with our website. This includes information about how you use our website, the pages you visit, the time spent on those pages, and other related statistics.
+Under the GDPR, we must have a "legal basis" for using your data. Here is why we use it:
 
-## 3. How We Use Your Information
+- **To Manage our Volunteer Network:** We use your information to organize our community, contact you via Airtable, and coordinate PauseAI events and activities.
+  - _Legal basis:_ **Legitimate interest** (to successfully run our non-profit volunteer organization).
+- **To Send our Newsletter:** If you choose to subscribe to our newsletter, we will add your email to our [Substack list](https://pauseai.substack.com/).
+  - _Legal basis:_ **Your explicit consent**.
+- **To Improve our Website:** We analyze website traffic to make our site better.
+  - _Legal basis:_ **Legitimate interest**.
 
-We use the collected information for the following purposes:
+## 4. Who Has Access to Your Data?
 
-### a. Providing and Improving Our Services
+We never sell or trade your personal information. However, we do share it in the following necessary circumstances:
 
-- To manage your membership and provide you with relevant information and updates.
-- To improve our website and services based on the usage data we collect.
+- **Authorized PauseAI Volunteers:** Your data may be accessed by certain PauseAI volunteers who help manage our operations. Any volunteer granted access to this data is required to sign a strict confidentiality agreement.
+- **Your National Chapter:** Because PauseAI is a global movement, we may share your contact information with the PauseAI national chapter in your country so they can coordinate local volunteer efforts with you. Please note that these national chapters are sometimes legally separate entities from Stichting PauseAI.
+- **Service Providers:** We use trusted third-party tools to run our operations, including Airtable (for our database), Substack (for our newsletter), and Google Analytics.
+- **Legal Requirements:** We may disclose your information if legally required to do so by public authorities.
 
-### b. Communication
+## 5. International Data Transfers
 
-- To reach out to members using Airtable for internal communications and updates about PauseAI events, activities, and other relevant information.
-- If you agree to subscribe to our newsletter, we add your email to substack as a subscriber to [our newsletter](https://pauseai.substack.com/).
+Because we use international service providers (like Airtable and Substack) and work with legally distinct national chapters around the world, your data may be transferred outside the European Economic Area (EEA). When this happens, we ensure your data remains protected by relying on recognized legal safeguards, such as the EU-US Data Privacy Framework or Standard Contractual Clauses.
 
-## 4. Disclosure of Your Information
+## 6. Data Retention
 
-We do not sell, trade, or otherwise transfer your personal information to outside parties. However, we may share your information in the following circumstances:
+We only keep your personal data for as long as necessary.
 
-### a. Service Providers
+- **Volunteer Data:** We keep your information as long as you are an active member, volunteer or follower. If you ask us to delete your data, we will securely remove it from our systems within 30 days.
+- **Newsletter Data:** We keep your email address on Substack until you click "unsubscribe" at the bottom of our emails.
 
-We may share your information with third-party service providers, such as Airtable, Substack and Google Analytics, to assist us in operating our website and conducting our activities.
+## 7. Data Security
 
-### b. Legal Requirements
+We implement strong security measures to keep your data safe. Your personal information is stored on secure networks, protected by passwords and multi-factor authentication where possible, and is only accessible by a limited number of authorized individuals.
 
-We may disclose your information if required to do so by law or in response to valid requests by public authorities.
+## 8. Your Privacy Rights
 
-### c. Chapter leaders
+Under the GDPR, you have the right to:
 
-We may share your contact information of the PauseAI national chapter leader of your country.
+- **Access** the personal data we hold about you.
+- **Correct** any mistakes in your data.
+- **Delete** your data ("right to be forgotten").
+- **Withdraw your consent** at any time (e.g., unsubscribing from the newsletter).
+- **Restrict or Object** to how we process your data.
+- **Request Data Portability** (receive a copy of your data in a digital format).
 
-## 5. Data Security
+If you want to exercise any of these rights, please [contact us](/contact-us). We will respond to your request within 30 days.
 
-We implement a variety of security measures to maintain the safety of your personal information. Your personal information is stored in secure networks and is only accessible by a limited number of persons who have special access rights to such systems and are required to keep the information confidential.
+If you are unhappy with how we handle your data, you also have the right to file a complaint with the Dutch Data Protection Authority (_Autoriteit Persoonsgegevens_).
 
-## 6. Your Rights
+## 9. Changes to This Privacy Policy
 
-You have the right to access, correct, or delete your personal information. If you wish to exercise these rights or have any questions about our privacy practices, please contact us.
-
-## 7. Changes to This Privacy Policy
-
-We may update this Privacy Policy from time to time. Any changes will be posted on this page with an updated effective date.
-
-## 8. Contact Us
-
-If you have any questions or concerns about this Privacy Policy, please contact us at:
-
-**Stichting PauseAI**
-[maxime@pauseai.info](mailto:maxime@pauseai.info)
-
-By using our website and services, you consent to the terms outlined in this Privacy Policy.
+We may update this policy occasionally as our organization grows. Any changes will be posted on this page with an updated "Effective Date" at the top.

--- a/src/posts/privacy.md
+++ b/src/posts/privacy.md
@@ -13,8 +13,8 @@ This Privacy Policy explains how [Stichting PauseAI](/legal) ("we," "us," "our")
 **Stichting PauseAI details:**
 
 - **Email:** [maxime@pauseai.info](mailto:maxime@pauseai.info)
-- **Address:** [Insert physical address of Stichting PauseAI]
-- **KVK Number:** [Insert Chamber of Commerce number]
+- **Address:** Box C5957, Kwikstaartlaan 42, 3704GS Zeist, The Netherlands
+- **KVK Number:** 92951031
 
 ## 2. Information We Collect
 


### PR DESCRIPTION
## Summary
- Rewrites [src/posts/privacy.md](src/posts/privacy.md) with a clearer, GDPR-aligned version covering legal basis, data retention, international transfers, and the full set of GDPR data subject rights.
- Bumps the **Effective Date** to April 17th, 2026 (following the existing convention — no version number, just an effective date).
- Note: the organization's physical address and KVK number are placeholders (`[Insert ...]`) and should be filled in before merging.

## Test plan
- [ ] Visit `/privacy` on the preview build and verify rendering, headings, and links resolve.
- [ ] Confirm the `[Insert physical address of Stichting PauseAI]` and `[Insert Chamber of Commerce number]` placeholders are replaced with real values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)