### PR TITLE
Fix whitespace above title on short pages (SearchModal grid stretch)

### DIFF
--- a/src/lib/stores/searchModal.ts
+++ b/src/lib/stores/searchModal.ts
@@ -1,0 +1,3 @@
+import { writable } from 'svelte/store'
+
+export const searchOpen = writable(false)

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -7,7 +7,9 @@
 	import Link from '$lib/components/Link.svelte'
 	import NearbyEvent from '$lib/components/NearbyEvent.svelte'
 	import PreloadFonts from '$lib/components/PreloadFonts.svelte'
+	import SearchModal from '$lib/components/SearchModal.svelte'
 	import Toc from '$lib/components/Toc.svelte'
+	import { searchOpen } from '$lib/stores/searchModal'
 	import { deLocalizeHref } from '$lib/paraglide/runtime'
 	import '@fontsource/roboto-slab/300.css'
 	import '@fontsource/roboto-slab/500.css'
@@ -193,6 +195,8 @@
 
 	<Footer />
 </div>
+
+<SearchModal bind:open={$searchOpen} />
 
 <Toaster
 	toastOptions={{

--- a/src/routes/header.svelte
+++ b/src/routes/header.svelte
@@ -2,20 +2,18 @@
 	import Navbar from '$lib/components/navbar/Navbar.svelte'
 	import Navlink from '$lib/components/navbar/Navlink.svelte'
 	import LanguageSwitcher from '$lib/components/LanguageSwitcher.svelte'
-	import SearchModal from '$lib/components/SearchModal.svelte'
 	import * as m from '$lib/paraglide/messages.js'
 	import { botName } from '$lib/config'
+	import { searchOpen } from '$lib/stores/searchModal'
 	import SearchIcon from 'lucide-svelte/icons/search'
 
 	const enableBot = false
 
 	export let inverted = false
 
-	let searchOpen = false
-
 	const openSearch = (e: MouseEvent) => {
 		e.preventDefault()
-		searchOpen = true
+		searchOpen.set(true)
 	}
 </script>
 
@@ -44,5 +42,3 @@
 		</Navlink>
 	</button>
 </Navbar>
-
-<SearchModal bind:open={searchOpen} />


### PR DESCRIPTION
Moves `<SearchModal>` out of `header.svelte` to the root layout so `<pagefind-modal>` stops occupying a row in the `.layout` grid.

## Before / After

/outcomes at viewport 1440×1800 — currently live on prod:

<table><tr>
<td><img width="500" alt="Before: empty gap on /outcomes" src="https://github.com/user-attachments/assets/73520df0-6845-4fef-b0a3-35ce0ed293da" /></td>
<td><img width="500" alt="After: no gap on /outcomes" src="https://github.com/user-attachments/assets/92e70323-3029-4205-9831-9e6119a2a0d3" /></td>
</tr></table>

Other prod pages also affected at tall viewports: /vacancies (~630px gap), /funding (~88px gap).

## The bug

`.layout` in `+layout.svelte` uses `grid-template-rows: auto 1fr auto`. `<SearchModal>` was rendered as a sibling of `<Navbar>` inside `header.svelte`, so `<pagefind-modal>` ended up as a direct grid child of `.layout`:

```
┌──────────────────┐   grid rows
│ navbar           │   auto
├──────────────────┤
│ pagefind-modal   │   1fr   ← absorbs empty space
│   (empty unless  │
│    opened)       │
├──────────────────┤
│ main             │   auto (implicit)
├──────────────────┤
│ footer           │   auto
└──────────────────┘
```

On pages whose content is shorter than the viewport, pagefind-modal stretched to fill the `1fr` row.

## The fix

Render `<SearchModal>` from `+layout.svelte` as a sibling of the layout grid (it's a global overlay, not header content). The open state moves to `src/lib/stores/searchModal.ts` so the header's search button can still trigger it.

## Test plan

- [ ] Visit /outcomes, /vacancies, /funding, or any short page on a tall viewport — title sits directly under the nav, no empty gap.
- [ ] Click the search icon in the nav — modal opens as before.
