### PR TITLE
Potential fix for code scanning alert no. 6: Double escaping or unescaping

### DIFF
--- a/src/routes/api/news/+server.ts
+++ b/src/routes/api/news/+server.ts
@@ -77,10 +77,10 @@ function decodeHtmlEntities(text: string): string {
 		.replace(/&#(\d+);/g, (_, dec) => String.fromCharCode(parseInt(dec, 10)))
 		.replace(/&#x([a-f\d]+);/gi, (_, hex) => String.fromCharCode(parseInt(hex, 16)))
 		.replace(/&quot;/g, '"')
-		.replace(/&amp;/g, '&')
 		.replace(/&lt;/g, '<')
 		.replace(/&gt;/g, '>')
 		.replace(/&apos;/g, "'")
+		.replace(/&amp;/g, '&')
 }
 
 function extractTag(xml: string, tag: string): string | null {


### PR DESCRIPTION
Potential fix for [https://github.com/PauseAI/pauseai-website/security/code-scanning/6](https://github.com/PauseAI/pauseai-website/security/code-scanning/6)

Fix by changing `decodeHtmlEntities` in `src/routes/api/news/+server.ts` so that ampersand decoding (`&amp;` → `&`) happens **after** all other entity decodings.

Best minimal fix (no functionality expansion) is:
- Keep numeric (`&#...;`) and hex (`&#x...;`) decoding as-is.
- Decode named entities like `&quot;`, `&lt;`, `&gt;`, `&apos;` first.
- Move `.replace(/&amp;/g, '&')` to the end.

This preserves current behavior while preventing double-unescape caused by early ampersand decoding.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
