### PR TITLE
Potential fix for code scanning alert no. 10: Untrusted Checkout TOCTOU

### DIFF
--- a/.github/workflows/format-command.yml
+++ b/.github/workflows/format-command.yml
@@ -41,13 +41,14 @@ jobs:
               pull_number: prNumber
             });
             core.setOutput('branch', pr.head.ref);
+            core.setOutput('sha', pr.head.sha);
             core.setOutput('repo', pr.head.repo.full_name);
 
       - name: Checkout PR branch
         uses: actions/checkout@v6
         with:
           repository: ${{ steps.get-pr.outputs.repo }}
-          ref: ${{ steps.get-pr.outputs.branch }}
+          ref: ${{ steps.get-pr.outputs.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: pnpm/action-setup@v6


### PR DESCRIPTION
Potential fix for [https://github.com/PauseAI/pauseai-website/security/code-scanning/10](https://github.com/PauseAI/pauseai-website/security/code-scanning/10)

Use an immutable commit reference for checkout and keep branch name only for pushing formatting commits.

Best fix in this file:
- In the **Get PR details** step, add a new output for `pr.head.sha` (e.g., `sha`).
- In the **Checkout PR branch** step, change `ref` from `${{ steps.get-pr.outputs.branch }}` to `${{ steps.get-pr.outputs.sha }}`.
- Keep `branch: ${{ steps.get-pr.outputs.branch }}` in `git-auto-commit-action` so pushes still target the PR branch as before.

This preserves functionality (format and push to PR branch) while preventing TOCTOU between authorization/check and execution.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
