### PR TITLE
Update roadmap with 2026 funding scenarios

### DIFF
--- a/src/posts/roadmap.md
+++ b/src/posts/roadmap.md
@@ -5,56 +5,83 @@ description: What are we planning to do and what could we do with more funding?
 
 ## Current situation
 
-- See our [funding page](/funding) for up-to-date info on how much we've received and from whom.
-- We have two paid FTEs: an Organizing Director and a Communications Director. All others are volunteers.
+PauseAI Global is the international coordinating body of the PauseAI federation. We support and coordinate national chapters across 15+ countries, train organisers, run global campaigns, and build the infrastructure that turns growing public concern about AI into organised political pressure.
+
+As of April 2026, we have a six-person team:
+
+- **Maxime Fournes** (CEO)
+- **Irina Tavera** (Organising Director)
+- **Jonathan Moody** (Communications Director)
+- Country organisers for the UK and France
+
+The France role has now transitioned to PauseAI France's own payroll, and the UK roles transition to PauseAI UK at the end of June 2026.
+
+See our [funding page](/funding) for up-to-date info on how much we've received and from whom.
+
+## Theory of change in brief
+
+Good policy proposals for AI governance already exist. Public concern about AI is surging. The missing link is an organised political constituency that converts concern into political action. PauseAI Global builds that constituency. We complement policy organisations who design specific proposals by building the movement that demands their adoption.
+
+A pause on frontier AI development requires multi-jurisdiction simultaneous pressure: coordinated domestic mobilisation in several major countries at once. A federation of national chapters running coordinated campaigns is the structure designed to produce exactly that. For more detail, see our [Theory of Change](/theory-of-change).
 
 ## Funding Scenarios
 
-### Scenario 0: No additional funding
+The scenarios below describe what PauseAI Global can do at different funding levels over a 12-month period. They reflect a calibration exercise in early 2026, mapping our theory of change to the resources actually required to execute it.
 
-Almost every person working on PauseAI is doing so voluntarily, so our burn rate is very low.
-We have around €90k in the bank.
+### Scenario 0: Minimum (€300k)
 
-- Facilitate the formation of new National and Local groups. Provide them with help, guidance, materials and funding.
-- Organize protests and other events to raise awareness about the issue and grow our community.
-- Organize letter writing workshops to push the national-level politicians to initialize treaty negotiations.
-- Build alliances with other organizations and overlapping cause areas to amplify our impact. E.g. artists, concerned parents, climate activists, job unions, etc.
-- Grow our social media presence through regular posts and engagement.
-- Participate in more [podcasts and interviews](/press).
-- Create more video content (focused on shorts) to reach a wider audience.
-- Get (paid) help from experts in various fields (marketing, policy, AI safety, community organizing, protesting, etc.) to learn from their experience and improve our work.
-- Experiment with social media ads to grow our community and learn what works.
-- Reach out to politicians and influencers.
-- Spend our remaining budget on PauseAI community projects through our MicroGrants program.
+Sustains the core team and a minimal level of programme activity. We maintain the executive team (CEO, Organising Director, Communications Director) and keep the federation infrastructure running, but cannot complete the team needed to scale operations. Programme activity is limited to two PauseCon conference, modest chapter support, and two coordinated global campaigns. New hiring is paused.
 
-### Scenario 1: €200k funding
+This is the level at which the organisation continues to exist and function, but does not grow.
 
-- All of the above, plus:
-- Hire **National / Regional directors** for our most impactful areas (UK, France).
-- Organize more [PauseCon](https://pausecon.org/) events to train our volunteers/organizers.
-- Set up an international pipeline for (video) content. Make it easier for national groups to consistently post high-quality, translated content to grow their impact.
-- Increase our spending on Ads on various social media platforms.
-- Increase our MicroGrants budget, allowing us to fund more community projects.
+### Scenario 1: Base (€900k)
 
-### Scenario 2: €600k funding
+Completes the eight-person team that coordinates the global federation and sustains core programme activity.
 
-- All of the above, plus:
-- Hire a **policy director** who will help us strategize and execute our policy goals. This person should help us educate volunteers on how to lobby effectively and help us with our policy proposals. This person needs to have international legal expertise and preferably knowledge in AI or technology policy/governance.
-- Hire a **press director** who will help us get more media coverage. This person should have experience in PR and media relations.
-- Drastically increased ads & MicroGrants budgets, leading to more growth and impactful community projects.
+**New hires (in priority order):**
 
-### Scenario 3: €1.2M+ funding
+- **Operations Director**: manages finances, HR, tech, contractor relationships, compliance and reporting (currently absorbed by the CEO).
+- **Development / Fundraising Director**: builds a sustainable funding pipeline so the organisation is never one grant away from closing down.
+- **Regional Organiser (1)**: dedicated coordinator for a high-potential region (likely continental Europe or Asia-Pacific).
+- **Policy / Strategy Director**: maintains relationships with policy partners, develops our asks, briefs politicians who need detailed proposals.
+- **Regional Organiser (2)**: second regional coordinator, extending federation support.
 
-- All of the above, plus:
-- Have more funding available for [national](https://pauseai.info/national-groups) and local PauseAI chapters.
-- Hire a PR agency to help us set up a large-scale international media campaign with a petition, advertisements.
+**Programme activity:**
+
+- Two PauseCon conferences per year (training the next generation of organisers).
+- Quarterly coordinated global campaigns across all chapters.
+- Meaningful seed funding for 8+ chapters: local events, materials, protests, legal setup.
+- At least two coordinated global protests.
+- Sustained CEO media presence, thought leadership, press releases, video content.
+- Investment in developing chapters in Asia, including China.
+
+### Scenario 2: Ambitious (€3.5M)
+
+Funds three capabilities the base tier cannot deliver.
+
+**Sustained narrative production.** Two Content Creators, a Social Media Lead, a PR firm retainer for crisis communications and warning-shot amplification, and a Chief of Staff managing culture and onboarding. Together these enable continuous public-facing narrative on frontier AI risk rather than reactive communications.
+
+**Paid-media capacity (€1M PR campaigns budget).** The first paid-reach operation in PauseAI Global's history. Earned media has a ceiling: the audiences who already read those outlets. Paid campaigns reach the communities we need next: students entering an AI-disrupted labour market, workers in sectors already being automated, democracy advocates tracking AI's effects on elections.
+
+**Treaty-lane infrastructure.** Two Senior Public Affairs Directors embedded in priority jurisdictions (likely UK and EU), a Legal Advisor on retainer for multi-jurisdiction regulatory expertise, and Regional Organiser capacity expanded from two to five. This staffing lets us carry a coordinated policy ask across multiple governments simultaneously.
+
+**Programme budgets scale with staff.** PauseCons become serious international convenings with paid speakers, policymaker guests, and professional production. Chapter seed funding rises to €400k, supporting 8+ chapters substantively. Protest capacity expands to enable more coordinated cross-jurisdiction actions.
+
+### Scenario 3: Maximum (€8.5M)
+
+The maximum we estimate we could meaningfully absorb in 12 months. Funds the ambitious tier plus four additional capabilities:
+
+- **Chapter seeding at scale (~€1M).** Direct seed funding and operational support for ten or more new chapters in priority jurisdictions. A portfolio bet: not all ten will develop into high-performing chapters, but five or six outstanding chapters could match the trajectories of PauseAI UK, France and Germany.
+- **Incubation of adjacent organisations (~€1.5M).** Funding to spin up two or three organisations the pause ecosystem currently lacks. Candidates include a dedicated elite defection capture organisation (legal cover, platforming and journalist relationships for AI company whistleblowers), a warning shot conversion media operation, and a specialised treaty-lane policy organisation.
+- **Direct country-leadership funding (~€1.5M).** Dedicated funding for country-level leadership in four or five priority jurisdictions where chapters are not yet self-sustaining, allowing them to stand up without premature self-sustainment pressure.
+- **Substantial paid-media capacity (~€1M additional).** Sustained public affairs advertising in priority jurisdictions, complementing earned media and creating sustained presence across the news cycle.
 
 ## Related documents
 
 - [Proposal](/proposal)
+- [Theory of Change](/theory-of-change)
 - [Values](/values)
 - [Donate](/donate)
-- [Legal](/legal)
 - [MicroGrants](/microgrants)
-- [Theory of Change](/theory-of-change)
 - [Funding](/funding)
+- [Legal](/legal)


### PR DESCRIPTION
## Summary
- Rewrites the roadmap page around the four 2026 funding scenarios (€300k / €900k / €3.5M / €8.5M).
- Adds current team context (April 2026) and a short theory-of-change summary.

## Test plan
- [ ] Visit /roadmap in preview and confirm the page renders correctly with all sections and links.