### PR TITLE
Potential fix for code scanning alert no. 3: Inefficient regular expression

### DIFF
--- a/src/lib/airtable.ts
+++ b/src/lib/airtable.ts
@@ -7,8 +7,7 @@ const getWriteApiKey = () => env.AIRTABLE_WRITE_API_KEY || env.AIRTABLE_API_KEY
 
 type QueryParams = Parameters<Table<FieldSet>['select']>[0]
 
-const AIRTABLE_URL_REGEX =
-	/^https:\/\/api\.airtable\.com\/v0\/(?<baseId>\w+)\/(?<tableId>\w+)\/?$/
+const AIRTABLE_URL_REGEX = /^https:\/\/api\.airtable\.com\/v0\/(?<baseId>\w+)\/(?<tableId>\w+)\/?$/
 
 export type AirtableRecord<T> = {
 	id: string

--- a/src/lib/airtable.ts
+++ b/src/lib/airtable.ts
@@ -8,7 +8,7 @@ const getWriteApiKey = () => env.AIRTABLE_WRITE_API_KEY || env.AIRTABLE_API_KEY
 type QueryParams = Parameters<Table<FieldSet>['select']>[0]
 
 const AIRTABLE_URL_REGEX =
-	/^https:\/\/api\.airtable\.com\/v0\/(?<baseId>(\w|\d)+)\/(?<tableId>(\w|\d)+)\/?$/
+	/^https:\/\/api\.airtable\.com\/v0\/(?<baseId>\w+)\/(?<tableId>\w+)\/?$/
 
 export type AirtableRecord<T> = {
 	id: string


### PR DESCRIPTION
Potential fix for [https://github.com/PauseAI/pauseai-website/security/code-scanning/3](https://github.com/PauseAI/pauseai-website/security/code-scanning/3)

General fix: remove ambiguous alternation inside repetition by replacing `(\w|\d)+` with a single non-overlapping character class (or equivalent shorthand). Since `\d` is already included in `\w`, the simplest behavior-preserving fix is to use `\w+`.

Best fix here (single-file, minimal behavior change): in `src/lib/airtable.ts`, update `AIRTABLE_URL_REGEX` on line 11 to replace both `(?<baseId>(\w|\d)+)` and `(?<tableId>(\w|\d)+)` with `(?<baseId>\w+)` and `(?<tableId>\w+)`. No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
