### PR TITLE
Split hero into generic slogan + current-campaign section

### DIFF
--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -1,24 +1,23 @@
 <script lang="ts">
 	import homeHeroDesktop from '$assets/protests/Home Hero - web - No Background.png?enhanced'
 	import homeHeroMobile from '$assets/protests/Home Hero - mobile - No Background.png?enhanced'
-	import { onMount } from 'svelte'
-	import { emulateCqwIfNeeded } from '$lib/container-query-units'
 
 	import Link from '$lib/components/Link.svelte'
 
-	let tagline: HTMLDivElement
-
-	onMount(() => {
-		const cleanupCqwEmulation = emulateCqwIfNeeded(tagline)
-
-		return () => {
-			cleanupCqwEmulation?.()
-		}
-	})
+	// Current campaign. Update this block when the active campaign changes.
+	const campaign = {
+		label: 'Active campaign — May 2026',
+		title: '“AI is not just coming for your job”',
+		aboutHref: '/action',
+		description:
+			'Workers, parents and patients are feeling it first. Add your story to the public record and help us hold the labs accountable.',
+		primary: { href: 'https://tally.so/r/GxBRr2', label: 'Share your story' },
+		secondary: { href: '/proposal', label: 'Read the brief' }
+	}
 </script>
 
 <div class="hero">
-	<picture>
+	<picture class="hero-photo">
 		{#each Object.entries(homeHeroMobile.sources) as [format, srcset]}
 			<source media="(max-width: 850px)" {srcset} sizes="100vw" type={'image/' + format} />
 		{/each}
@@ -27,106 +26,47 @@
 		{/each}
 		<img src={homeHeroDesktop.img.src} alt="" fetchpriority="high" />
 	</picture>
-	<div class="content" bind:this={tagline}>
-		<h2>Don't let AI companies<br />gamble away our future</h2>
-		<div class="actions">
-			<Link href="/join" class="btn-primary">Get involved</Link>
-			<Link href="/donate" class="btn-secondary">Donate</Link>
+
+	<div class="hero-top">
+		<div class="hero-top-inner">
+			<h1>Join the movement to <em>Pause</em> AI.</h1>
+			<div class="hero-buttons">
+				<Link href="/join" class="btn-dark">Get involved</Link>
+				<Link href="/donate" class="btn-light">Donate</Link>
+			</div>
+		</div>
+	</div>
+
+	<div class="hero-band">
+		<div class="band-left">
+			<span class="band-dot" aria-hidden="true"></span>
+			<span class="band-label">{campaign.label}</span>
+			<span class="band-title">{campaign.title}</span>
+		</div>
+		<a href={campaign.aboutHref} class="band-link">About this campaign →</a>
+	</div>
+
+	<div class="hero-bottom">
+		<div class="hero-bottom-inner">
+			<h2>AI is not <em>just</em> coming for your job.</h2>
+			<p class="hero-copy">{campaign.description}</p>
+			<div class="hero-buttons">
+				<Link href={campaign.primary.href} class="btn-dark">{campaign.primary.label}</Link>
+				<Link href={campaign.secondary.href} class="btn-light">{campaign.secondary.label}</Link>
+			</div>
 		</div>
 	</div>
 </div>
 
 <style>
-	.content {
-		position: absolute;
-		top: 45%;
-		left: 20%;
-		transform: translateY(-50%);
-		width: clamp(20rem, 60vw, 100%);
-		container-type: inline-size;
-		--cqw: 1cqw;
-		display: flex;
-		flex-direction: column;
-		gap: 1.5rem;
-	}
-
-	.content h2 {
-		color: white;
-		font-family: var(--font-heading);
-		font-weight: 700;
-		font-size: calc(6 * var(--cqw));
-		line-height: 1.1;
-		text-align: left;
-		margin: 0;
-		text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
-	}
-
-	.hero :global(img) {
-		position: absolute;
-		bottom: 0;
-		left: 50%;
-		--hero-scale: 1;
-		transform: translateX(-50%) scale(var(--hero-scale));
-		width: min(100%, calc(max(100vh, var(--hero-min-height)) * var(--hero-img-ar)));
-		height: auto;
-		mix-blend-mode: soft-light;
-	}
-
-	@media (min-width: 851px) {
-		.hero :global(img) {
-			transform-origin: center bottom;
-			--hero-scale: 0.95;
-			-webkit-mask-image: linear-gradient(to right, transparent, black 10%, black 90%, transparent);
-			mask-image: linear-gradient(to right, transparent, black 10%, black 90%, transparent);
-		}
-	}
-
-	@media (max-width: 850px) {
-		.hero :global(img) {
-			bottom: var(--mobile-hero-img-pos, 0px);
-			-webkit-mask-image: linear-gradient(to top, transparent, black 20%);
-			mask-image: linear-gradient(to top, transparent, black 20%);
-		}
-
-		.content {
-			top: auto;
-			bottom: 5vh;
-			left: 50%;
-			transform: translateX(-50%);
-			width: 90%;
-			text-align: center;
-			align-items: center;
-			z-index: 1;
-		}
-
-		.content h2 {
-			font-size: calc(9 * var(--cqw));
-			text-align: center;
-		}
-
-		.actions {
-			justify-content: center;
-		}
-
-		.actions :global(a.btn-primary),
-		.actions :global(a.btn-secondary) {
-			background-color: transparent;
-			backdrop-filter: blur(2px);
-			border: 2px solid white;
-			color: white;
-		}
-	}
-
 	.hero {
-		display: block;
-		height: 100%;
-		overflow: hidden;
 		position: relative;
 		width: 100vw;
 		left: 50%;
 		transform: translateX(-50%);
 		background-color: #ff9416;
 		isolation: isolate;
+		color: white;
 
 		/* Desktop hero image aspect ratio (2880 / 1600) — update if image changes */
 		--hero-img-ar: 1.8;
@@ -134,44 +74,265 @@
 		--mobile-hero-img-pos: 215px;
 	}
 
-	.actions {
-		display: flex;
-		gap: 1rem;
-		justify-content: flex-start;
+	/* Full-hero protest photo — covers top + bottom sections behind the band.
+	   Soft-light blend tints the photo with the orange hero background.
+	   No z-index on the wrapper so the blend can reach the orange below;
+	   `isolation: isolate` on .hero keeps the blend scoped to the hero. */
+	.hero {
+		overflow: hidden;
 	}
 
-	/* Global styles for Link component when used here */
-	.actions :global(a) {
+	.hero-photo {
+		position: absolute;
+		inset: 0;
+		pointer-events: none;
+		display: block;
+	}
+	.hero-photo :global(img) {
+		position: absolute;
+		/* Fill the full hero height; width scales to keep aspect ratio.
+		   Anchored to the right so the megaphone protester always shows;
+		   the left side is cropped on narrower viewports. */
+		right: 0;
+		bottom: 0;
+		height: 100%;
+		width: auto;
+		max-width: none;
+		mix-blend-mode: soft-light;
+	}
+
+	@media (min-width: 851px) {
+		.hero-photo :global(img) {
+			-webkit-mask-image: linear-gradient(to right, transparent, black 18%);
+			mask-image: linear-gradient(to right, transparent, black 18%);
+		}
+	}
+
+	@media (max-width: 850px) {
+		.hero-photo :global(img) {
+			/* On phones the image cropping becomes too aggressive when forced
+			   to fill the height — use the original bottom-anchored layout. */
+			right: auto;
+			left: 50%;
+			height: auto;
+			width: calc(var(--mobile-hero-width-scale, 1.4) * 100%);
+			transform: translateX(-50%);
+			bottom: var(--mobile-hero-img-pos, 0px);
+			-webkit-mask-image: linear-gradient(to top, transparent, black 20%);
+			mask-image: linear-gradient(to top, transparent, black 20%);
+		}
+	}
+
+	/* TOP — generic slogan, sits over the shared photo. */
+	.hero-top {
+		position: relative;
+	}
+
+	.hero-top-inner {
+		position: relative;
+		z-index: 1;
+		padding: 13rem clamp(1.5rem, 4vw, 3.5rem) 2.75rem;
+	}
+	.hero-top-inner h1 {
 		font-family: var(--font-heading);
-		text-decoration: none;
-		font-size: 1rem;
-		padding: 0.6rem 1.6rem;
+		font-weight: 700;
+		font-size: clamp(2.5rem, 5.8vw, 5.5rem);
+		line-height: 1.02;
+		color: white;
+		margin: 0;
+		max-width: 16ch;
+		letter-spacing: 0.005em;
+		text-shadow: 0 2px 4px rgba(0, 0, 0, 0.18);
+	}
+	.hero-top-inner h1 em {
+		color: #111110;
+		font-style: normal;
+	}
+	.hero-top-inner .hero-buttons {
+		margin-top: 1.5rem;
+	}
+
+	/* BAND — current campaign label */
+	.hero-band {
+		position: relative;
+		z-index: 2;
+		background: #111110;
+		color: white;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 1.5rem;
+		padding: 1rem clamp(1.5rem, 4vw, 3.5rem);
+		flex-wrap: wrap;
+	}
+	.band-left {
+		display: flex;
+		align-items: center;
+		gap: 1rem;
+		flex-wrap: wrap;
+	}
+	.band-dot {
+		width: 10px;
+		height: 10px;
+		border-radius: 50%;
+		background: #fe9414;
+		flex-shrink: 0;
+		animation: heroPulse 1.8s ease-in-out infinite;
+	}
+	@keyframes heroPulse {
+		0%,
+		100% {
+			opacity: 1;
+			transform: scale(1);
+		}
+		50% {
+			opacity: 0.55;
+			transform: scale(0.8);
+		}
+	}
+	.band-label {
+		font-family: var(--font-heading);
+		font-weight: 700;
+		letter-spacing: 0.18em;
 		text-transform: uppercase;
-		transition: scale 0.1s;
-		cursor: pointer;
-		border-radius: 4px; /* Slight rounding if desired, or keep square */
-		font-weight: bold;
+		font-size: 0.8125rem;
+		color: #fe9414;
+	}
+	.band-title {
+		font-family: var(--font-heading);
+		font-weight: 700;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		font-size: 1.125rem;
+		color: white;
+	}
+	.band-link {
+		font-family: var(--font-heading);
+		font-weight: 700;
+		letter-spacing: 0.16em;
+		text-transform: uppercase;
+		font-size: 0.8125rem;
+		color: white;
+		opacity: 0.75;
+		text-decoration: none;
+		transition: opacity 0.15s;
+	}
+	.band-link:hover {
+		opacity: 1;
+	}
+
+	/* BOTTOM — current campaign content */
+	.hero-bottom {
+		position: relative;
+		min-height: 360px;
+	}
+	.hero-bottom-inner {
+		padding: 3.25rem clamp(1.5rem, 4vw, 3.5rem) 4rem;
+		display: flex;
+		flex-direction: column;
+		gap: 1.25rem;
+	}
+	.hero-bottom h2 {
+		font-family: var(--font-heading);
+		font-weight: 700;
+		font-size: clamp(2.25rem, 4.8vw, 4.375rem);
+		line-height: 1.04;
+		color: white;
+		margin: 0;
+		max-width: 17ch;
+		text-shadow: 0 2px 4px rgba(0, 0, 0, 0.12);
+	}
+	.hero-bottom h2 em {
+		color: #111110;
+		font-style: normal;
+	}
+	.hero-copy {
+		color: white;
+		font-size: 1.0625rem;
+		line-height: 1.55;
+		max-width: 44rem;
+		margin: 0;
+	}
+
+	/* Buttons — match live-site look: solid fills, square, condensed bold. */
+	.hero-buttons {
+		display: flex;
+		gap: 0.75rem;
+		flex-wrap: wrap;
+	}
+	.hero-buttons :global(a) {
+		font-family: var(--font-heading);
+		font-weight: 700;
+		letter-spacing: 0.06em;
+		font-size: 0.875rem;
+		text-transform: uppercase;
+		padding: 0.875rem 1.375rem;
+		border: 0;
+		border-radius: 4px;
+		text-decoration: none;
 		display: inline-block;
 		text-align: center;
+		transition:
+			background-color 0.15s,
+			scale 0.1s;
+		cursor: pointer;
 	}
-
-	.actions :global(a.btn-primary) {
-		background-color: #1a1a1a; /* Dark button */
+	.hero-buttons :global(a.btn-dark) {
+		background: #111110;
 		color: white;
-		border: 2px solid #1a1a1a;
+	}
+	.hero-buttons :global(a.btn-dark:hover) {
+		background: #1a1916;
+	}
+	.hero-buttons :global(a.btn-light) {
+		background: white;
+		color: #111110;
+	}
+	.hero-buttons :global(a.btn-light:hover) {
+		background: #f0ebe2;
+	}
+	.hero-buttons :global(a:active) {
+		scale: 0.97;
 	}
 
-	.actions :global(a.btn-secondary) {
-		background-color: white;
-		color: black;
-		border: 2px solid white;
-	}
+	@media (max-width: 850px) {
+		.hero-top {
+			min-height: 420px;
+		}
+		.hero-top-inner {
+			padding: 14rem 1.5rem 2rem;
+		}
+		.hero-top-inner h1 {
+			font-size: clamp(2rem, 9vw, 3rem);
+			max-width: none;
+		}
 
-	.actions :global(a:hover) {
-		scale: 1.05;
-	}
+		.hero-band {
+			padding: 0.875rem 1.5rem;
+			gap: 0.75rem;
+		}
+		.band-label {
+			font-size: 0.75rem;
+		}
+		.band-title {
+			font-size: 0.95rem;
+		}
+		.band-link {
+			display: none;
+		}
 
-	.actions :global(a:active) {
-		scale: 0.95;
+		.hero-bottom {
+			min-height: 0;
+		}
+		.hero-bottom-inner {
+			padding: 2rem 1.5rem 2.5rem;
+		}
+		.hero-bottom h2 {
+			font-size: clamp(1.75rem, 8vw, 2.5rem);
+			max-width: none;
+		}
+		.hero-copy {
+			font-size: 1rem;
+		}
 	}
 </style>

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -8,7 +8,8 @@
 	const campaign = {
 		description:
 			'AI labs are explicitly racing to automate every job on the planet, including yours, within years. And job loss is only the tip of the iceberg.',
-		primary: { href: 'https://tally.so/r/GxBRr2', label: 'Share your story' }
+		primary: { href: 'https://tally.so/r/GxBRr2', label: 'Share your story' },
+		secondary: { href: '/ai-not-just-coming-for-your-job', label: 'Read more' }
 	}
 </script>
 

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -6,13 +6,9 @@
 
 	// Current campaign. Update this block when the active campaign changes.
 	const campaign = {
-		label: 'Active campaign — May 2026',
-		title: '“AI is not just coming for your job”',
-		aboutHref: '/action',
 		description:
-			'Workers, parents and patients are feeling it first. Add your story to the public record and help us hold the labs accountable.',
-		primary: { href: 'https://tally.so/r/GxBRr2', label: 'Share your story' },
-		secondary: { href: '/proposal', label: 'Read the brief' }
+			'AI labs are explicitly racing to automate every job on the planet, including yours, within years. And job loss is only the tip of the iceberg.',
+		primary: { href: 'https://tally.so/r/GxBRr2', label: 'Share your story' }
 	}
 </script>
 
@@ -37,22 +33,19 @@
 		</div>
 	</div>
 
-	<div class="hero-band">
-		<div class="band-left">
-			<span class="band-dot" aria-hidden="true"></span>
-			<span class="band-label">{campaign.label}</span>
-			<span class="band-title">{campaign.title}</span>
-		</div>
-		<a href={campaign.aboutHref} class="band-link">About this campaign →</a>
-	</div>
-
 	<div class="hero-bottom">
 		<div class="hero-bottom-inner">
+			<span class="hero-badge">
+				<span class="hero-badge-dot" aria-hidden="true"></span>
+				Active campaign
+			</span>
 			<h2>AI is not <em>just</em> coming for your job.</h2>
 			<p class="hero-copy">{campaign.description}</p>
 			<div class="hero-buttons">
 				<Link href={campaign.primary.href} class="btn-dark">{campaign.primary.label}</Link>
-				<Link href={campaign.secondary.href} class="btn-light">{campaign.secondary.label}</Link>
+				{#if campaign.secondary}
+					<Link href={campaign.secondary.href} class="btn-light">{campaign.secondary.label}</Link>
+				{/if}
 			</div>
 		</div>
 	</div>
@@ -74,10 +67,8 @@
 		--mobile-hero-img-pos: 215px;
 	}
 
-	/* Full-hero protest photo — covers top + bottom sections behind the band.
-	   Soft-light blend tints the photo with the orange hero background.
-	   No z-index on the wrapper so the blend can reach the orange below;
-	   `isolation: isolate` on .hero keeps the blend scoped to the hero. */
+	/* Protest photo — spans the full hero behind both sections, soft-light
+	   blended into the orange background. */
 	.hero {
 		overflow: hidden;
 	}
@@ -123,7 +114,7 @@
 		}
 	}
 
-	/* TOP — generic slogan, sits over the shared photo. */
+	/* TOP — generic slogan, sits over the protest photo. */
 	.hero-top {
 		position: relative;
 	}
@@ -131,7 +122,8 @@
 	.hero-top-inner {
 		position: relative;
 		z-index: 1;
-		padding: 13rem clamp(1.5rem, 4vw, 3.5rem) 2.75rem;
+		padding-block: 10rem 3rem;
+		padding-inline: clamp(1.5rem, 20vw, 18rem);
 	}
 	.hero-top-inner h1 {
 		font-family: var(--font-heading);
@@ -152,28 +144,27 @@
 		margin-top: 1.5rem;
 	}
 
-	/* BAND — current campaign label */
-	.hero-band {
+	/* BADGE — small pill marking the active campaign */
+	.hero-badge {
 		position: relative;
-		z-index: 2;
+		z-index: 1;
+		align-self: flex-start;
+		display: inline-flex;
+		align-items: center;
+		gap: 0.5rem;
 		background: #111110;
 		color: white;
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		gap: 1.5rem;
-		padding: 1rem clamp(1.5rem, 4vw, 3.5rem);
-		flex-wrap: wrap;
+		font-family: var(--font-heading);
+		font-weight: 700;
+		letter-spacing: 0.16em;
+		text-transform: uppercase;
+		font-size: 0.75rem;
+		padding: 0.5rem 0.875rem;
+		border-radius: 999px;
 	}
-	.band-left {
-		display: flex;
-		align-items: center;
-		gap: 1rem;
-		flex-wrap: wrap;
-	}
-	.band-dot {
-		width: 10px;
-		height: 10px;
+	.hero-badge-dot {
+		width: 8px;
+		height: 8px;
 		border-radius: 50%;
 		background: #fe9414;
 		flex-shrink: 0;
@@ -190,36 +181,6 @@
 			transform: scale(0.8);
 		}
 	}
-	.band-label {
-		font-family: var(--font-heading);
-		font-weight: 700;
-		letter-spacing: 0.18em;
-		text-transform: uppercase;
-		font-size: 0.8125rem;
-		color: #fe9414;
-	}
-	.band-title {
-		font-family: var(--font-heading);
-		font-weight: 700;
-		letter-spacing: 0.04em;
-		text-transform: uppercase;
-		font-size: 1.125rem;
-		color: white;
-	}
-	.band-link {
-		font-family: var(--font-heading);
-		font-weight: 700;
-		letter-spacing: 0.16em;
-		text-transform: uppercase;
-		font-size: 0.8125rem;
-		color: white;
-		opacity: 0.75;
-		text-decoration: none;
-		transition: opacity 0.15s;
-	}
-	.band-link:hover {
-		opacity: 1;
-	}
 
 	/* BOTTOM — current campaign content */
 	.hero-bottom {
@@ -227,7 +188,8 @@
 		min-height: 360px;
 	}
 	.hero-bottom-inner {
-		padding: 3.25rem clamp(1.5rem, 4vw, 3.5rem) 4rem;
+		padding-block: 3rem 5rem;
+		padding-inline: clamp(1.5rem, 20vw, 18rem);
 		display: flex;
 		flex-direction: column;
 		gap: 1.25rem;
@@ -252,6 +214,8 @@
 		line-height: 1.55;
 		max-width: 44rem;
 		margin: 0;
+		font-weight: 500;
+		text-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
 	}
 
 	/* Buttons — match live-site look: solid fills, square, condensed bold. */
@@ -305,20 +269,6 @@
 		.hero-top-inner h1 {
 			font-size: clamp(2rem, 9vw, 3rem);
 			max-width: none;
-		}
-
-		.hero-band {
-			padding: 0.875rem 1.5rem;
-			gap: 0.75rem;
-		}
-		.band-label {
-			font-size: 0.75rem;
-		}
-		.band-title {
-			font-size: 0.95rem;
-		}
-		.band-link {
-			display: none;
 		}
 
 		.hero-bottom {

--- a/src/posts/ai-not-just-coming-for-your-job.md
+++ b/src/posts/ai-not-just-coming-for-your-job.md
@@ -1,0 +1,48 @@
+---
+title: AI is not just coming for your job
+description: AI labs are explicitly racing to automate every job on the planet, and that is only the tip of the iceberg.
+date: 2026-05-11
+---
+
+**AI labs are explicitly racing to automate every job on the planet, _including yours_, within years. And job loss is only the tip of the iceberg.**
+
+## AI is coming for your job
+
+This is not speculation, and it is not a side effect. It is the stated goal.
+
+OpenAI defines its mission as building "highly autonomous systems that outperform humans at most economically valuable work." Anthropic, Google DeepMind, Meta, and xAI are racing toward the same target, and their leaders say they are only a few years away. They are pouring hundreds of billions of dollars into systems designed to do what you do, faster, cheaper, and without a contract.
+
+Lawyers, designers, radiologists, software engineers, teachers, accountants, translators, customer service workers, screenwriters, drivers, analysts. Every desk job, every creative job, every job that runs on a screen is on the list. The labs are not hiding this. They are advertising it to investors as the reason their valuations make sense.
+
+If they succeed, the question is not whether your job survives. The question is what a society looks like when the people who used to do the work no longer have a seat at the table.
+
+## And job loss is only the tip of the iceberg
+
+The same race that is coming for your job is coming for everything else.
+
+The same systems are being deployed to decide who gets hired, who gets fired, who gets a loan, who gets a diagnosis, who gets bail, and what your children are taught. Decisions that used to be made by people, with someone to call when they got it wrong, are being handed to systems no one fully understands and no one is accountable for.
+
+And this is still only the beginning. The labs are not trying to build better tools. They are trying to build systems more capable than humans across every domain, including the domain of building more powerful AI. The same researchers building these systems openly acknowledge that they do not know how to keep such systems aligned with human values, or under human control. Many of them, including Nobel laureates and the most cited AI scientists alive, have warned that this trajectory could end in human extinction.
+
+This is not a fringe view. It is the position of the people building the technology. They are asking the world to trust that they will figure out safety on the way. We would not accept this from any other industry. We should not accept it now.
+
+## What this campaign is about
+
+We are calling for a pause on the development of the most dangerous AI systems until their builders can prove, to independent evaluators, that they are safe.
+
+No company should be allowed to deploy systems that reshape the economy, the information environment, and the balance of power without showing their work. The burden of proof belongs with the people doing the building, not with the rest of us.
+
+Over the coming months, PauseAI chapters around the world are:
+
+- Collecting stories from workers, students, parents, patients, and creatives about how AI is already changing their lives, and what they fear is coming next
+- Building coalitions with unions, student groups, parent associations, healthcare workers, and creative industries who are seeing the same pattern from different angles
+- Meeting with elected officials and decision makers to demand binding limits on frontier AI development, backed by international coordination
+- Preparing for a global day of action this summer to put public pressure on governments to act before it is too late
+
+This is not a campaign to save any one job. It is a campaign to make sure humans stay in charge of the future.
+
+## Share your story
+
+Has AI already affected your work, your studies, your healthcare, or your community? Are you worried about what comes next? Your story matters, and it is one of the most powerful tools we have to make decision makers listen.
+
+[Share your story](https://tally.so/r/GxBRr2)

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -242,7 +242,7 @@
 	.page-top.hero-page {
 		display: flex;
 		flex-direction: column;
-		height: 100dvh;
+		min-height: 100dvh;
 	}
 
 	.page-top.hero-page > :global(.banner) {


### PR DESCRIPTION
## Summary
- Split the home hero into a top section with the generic slogan + "Get involved" / "Donate" CTAs, and a bottom section dedicated to the current campaign.
- A compact "Active campaign" pill (with pulsing dot) sits above the campaign headline; the campaign content (headline, blurb, CTAs) lives in a single `campaign` object at the top of `Hero.svelte` for easy swap each cycle.
- Protest photo is shared across both sections, anchored to the right so the megaphone protester is always in frame; the left side crops on narrower viewports.
- Campaign blurb gets a subtle weight bump + soft text shadow so it stays readable against the photo.
- `.page-top.hero-page` switched from fixed `height: 100dvh` to `min-height: 100dvh` so the taller hero grows naturally rather than clipping the bottom section.

## How to update the campaign
Edit the `campaign` object at the top of `src/lib/components/Hero.svelte`:

```ts
const campaign = {
  description: '…',
  primary: { href: '…', label: 'Share your story' },
  // secondary is optional — add it back to render a second CTA
}
```

The campaign headline (currently `AI is not <em>just</em> coming for your job.`) is inline in the template — adjust there if the campaign changes.

## Test plan
- [ ] Visual check at desktop (1440 / 1280) — slogan and campaign aligned, photo spans both sections, megaphone protester visible
- [ ] Visual check at tablet (~768) — layout still readable, photo not over-cropped
- [ ] Visual check at mobile (375) — slogan clears the nav, badge + campaign content readable
- [ ] Confirm "Get involved", "Donate", "Share your story" links resolve correctly
- [ ] Confirm `prefers-reduced-motion` users aren't bothered by the pill's pulsing dot (it's subtle; happy to gate it on a preference if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)