### PR TITLE
[DIAG] Surface Airtable error in MP-email response

### DIFF
--- a/src/routes/api/uk-send-mp-email/+server.ts
+++ b/src/routes/api/uk-send-mp-email/+server.ts
@@ -185,7 +185,7 @@ export const POST: RequestHandler = async ({ request }) => {
 			return json(
 				{
 					error: 'server_error',
-					message: 'Failed to send email'
+					message: `Failed to send email [diag: ${response.status} ${response.statusText} ${errorText.slice(0, 500)}]`
 				} satisfies UKSendMPEmailApiResponse,
 				{ status: StatusCodes.INTERNAL_SERVER_ERROR }
 			)
@@ -200,7 +200,7 @@ export const POST: RequestHandler = async ({ request }) => {
 		return json(
 			{
 				error: 'server_error',
-				message: 'Failed to send email'
+				message: `Failed to send email [diag: caught ${String(error).slice(0, 500)}]`
 			} satisfies UKSendMPEmailApiResponse,
 			{ status: StatusCodes.INTERNAL_SERVER_ERROR }
 		)


### PR DESCRIPTION
Temporary diagnostic patch. The UK MP email endpoint is currently returning 500 in production with an opaque message; this surfaces the underlying Airtable error text in the response body so we can identify the cause without function-log access.

Test via the Netlify deploy preview's `/uk-email-mp` form — submit, then read the response body in the network tab. **Revert immediately after.**