### PR TITLE
Add Parliament-visit checkbox to UK MP email form

### DIFF
--- a/src/lib/components/UKMPEmailForm.svelte
+++ b/src/lib/components/UKMPEmailForm.svelte
@@ -45,6 +45,36 @@ ${userPostcode.toUpperCase()}`)
 	let submitStatus: 'idle' | 'success' | 'error' = $state('idle')
 	let errorMessage = $state('')
 
+	let attendingVisit = $state(false)
+	let messageBeforeVisit: string | null = $state(null)
+
+	const ORIGINAL_NEXT_STEPS = `Next steps
+ - 30-min call. Let me know what time would work for you.
+ - Alternatively, please review the letter and background information attached and send over any questions or concerns.`
+
+	const VISIT_SENTENCE = `**I will be visiting Parliament on Tuesday June 23rd. Will you meet with me to discuss the letter and your plan for addressing AI risks?**`
+
+	function toggleVisit() {
+		if (attendingVisit) {
+			messageBeforeVisit = message
+			if (message.includes(ORIGINAL_NEXT_STEPS)) {
+				message = message.replace(ORIGINAL_NEXT_STEPS, VISIT_SENTENCE)
+			} else {
+				// User has customised the Next steps section. Insert the visit sentence
+				// before the signature line so we don't trample their edits.
+				const signatureMarker = '\nThank you for your consideration'
+				if (message.includes(signatureMarker)) {
+					message = message.replace(signatureMarker, `\n${VISIT_SENTENCE}${signatureMarker}`)
+				} else {
+					message = `${message}\n\n${VISIT_SENTENCE}`
+				}
+			}
+		} else if (messageBeforeVisit !== null) {
+			message = messageBeforeVisit
+			messageBeforeVisit = null
+		}
+	}
+
 	let htmlPreview = $derived(micromark(message))
 
 	function insertMarkdown(before: string, after: string = '') {
@@ -217,6 +247,18 @@ ${userPostcode.toUpperCase()}`)
 					rows="1"
 					class="subject-textarea"
 				></textarea>
+			</div>
+
+			<div class="form-group visit-group">
+				<label class="visit-label">
+					<input type="checkbox" bind:checked={attendingVisit} onchange={toggleVisit} />
+					<span>
+						I will be attending PauseAI UK's
+						<Link href="https://luma.com/q2wu0y59?utm_source=uk-email-builder" target="_blank"
+							>visit to Parliament</Link
+						> to speak with my MP in person.
+					</span>
+				</label>
 			</div>
 
 			<div class="form-group">
@@ -414,6 +456,28 @@ ${userPostcode.toUpperCase()}`)
 		overflow: hidden;
 		white-space: pre-wrap;
 		word-wrap: break-word;
+	}
+
+	.visit-group {
+		padding-top: 1.5rem;
+	}
+
+	.visit-label {
+		display: flex;
+		align-items: flex-start;
+		gap: 0.6rem;
+		cursor: pointer;
+		font-weight: normal;
+		line-height: 1.4;
+	}
+
+	.visit-label input[type='checkbox'] {
+		width: auto;
+		margin: 0;
+		padding: 0;
+		flex-shrink: 0;
+		margin-top: 0.25rem;
+		cursor: pointer;
 	}
 
 	.email-tips {

--- a/src/lib/components/UKMPEmailForm.svelte
+++ b/src/lib/components/UKMPEmailForm.svelte
@@ -495,7 +495,6 @@ ${userPostcode.toUpperCase()}`)
 
 	.visit-tickbox {
 		appearance: none;
-		-webkit-appearance: none;
 		width: 1.15rem;
 		height: 1.15rem;
 		padding: 0;

--- a/src/lib/components/UKMPEmailForm.svelte
+++ b/src/lib/components/UKMPEmailForm.svelte
@@ -250,9 +250,14 @@ ${userPostcode.toUpperCase()}`)
 			</div>
 
 			<div class="form-group visit-group">
-				<label class="visit-label">
-					<input type="checkbox" bind:checked={attendingVisit} onchange={toggleVisit} />
-					<span>
+				<label class="visit-label" class:checked={attendingVisit}>
+					<input
+						type="checkbox"
+						class="visit-tickbox"
+						bind:checked={attendingVisit}
+						onchange={toggleVisit}
+					/>
+					<span class="visit-text">
 						I will be attending PauseAI UK's
 						<Link href="https://luma.com/q2wu0y59?utm_source=uk-email-builder" target="_blank"
 							>visit to Parliament</Link
@@ -465,19 +470,68 @@ ${userPostcode.toUpperCase()}`)
 	.visit-label {
 		display: flex;
 		align-items: flex-start;
-		gap: 0.6rem;
+		gap: 0.7rem;
 		cursor: pointer;
-		font-weight: normal;
-		line-height: 1.4;
+		padding: 0.85rem 1rem;
+		background: var(--bg);
+		border: 1px solid color-mix(in srgb, var(--brand) 28%, transparent);
+		border-radius: 8px;
+		font-weight: 400;
+		font-size: 0.95rem;
+		line-height: 1.45;
+		transition:
+			border-color 0.15s ease,
+			background-color 0.15s ease;
 	}
 
-	.visit-label input[type='checkbox'] {
-		width: auto;
-		margin: 0;
+	.visit-label:hover {
+		border-color: var(--brand);
+	}
+
+	.visit-label.checked {
+		border-color: var(--brand);
+		background: color-mix(in srgb, var(--brand) 10%, var(--bg));
+	}
+
+	.visit-tickbox {
+		appearance: none;
+		-webkit-appearance: none;
+		width: 1.15rem;
+		height: 1.15rem;
 		padding: 0;
+		margin: 0;
+		margin-top: 0.18rem;
 		flex-shrink: 0;
-		margin-top: 0.25rem;
+		border: 2px solid var(--brand);
+		border-radius: 4px;
+		background: var(--bg);
 		cursor: pointer;
+		display: grid;
+		place-content: center;
+	}
+
+	.visit-tickbox::before {
+		content: '';
+		width: 0.65rem;
+		height: 0.65rem;
+		transform: scale(0);
+		transition: transform 0.1s ease-in-out;
+		background: var(--brand);
+		clip-path: polygon(14% 44%, 0 65%, 50% 100%, 100% 16%, 80% 0%, 43% 62%);
+	}
+
+	.visit-tickbox:checked::before {
+		transform: scale(1);
+	}
+
+	.visit-tickbox:focus-visible {
+		outline: 2px solid var(--brand);
+		outline-offset: 2px;
+	}
+
+	.visit-text {
+		flex: 1;
+		min-width: 0;
 	}
 
 	.email-tips {

--- a/src/lib/components/UKMPEmailForm.svelte
+++ b/src/lib/components/UKMPEmailForm.svelte
@@ -64,7 +64,7 @@ ${userPostcode.toUpperCase()}`)
 				// before the signature line so we don't trample their edits.
 				const signatureMarker = '\nThank you for your consideration'
 				if (message.includes(signatureMarker)) {
-					message = message.replace(signatureMarker, `\n${VISIT_SENTENCE}${signatureMarker}`)
+					message = message.replace(signatureMarker, `\n${VISIT_SENTENCE}\n${signatureMarker}`)
 				} else {
 					message = `${message}\n\n${VISIT_SENTENCE}`
 				}


### PR DESCRIPTION
Adds a checkbox above the message field for users planning to attend [PauseAI UK's June 23rd visit to Parliament](https://luma.com/q2wu0y59) to speak with their MP in person.

When checked, the message's "Next steps" block is swapped for a bold sentence proposing an in-person meeting at Parliament. If the user has already customised the Next steps section, the sentence is inserted before the signature instead, so their edits aren't lost. Unchecking restores the message exactly as it was before the box was checked.

The luma link carries `utm_source=uk-email-builder`.

Styled as a soft brand-tinted card with a custom checkbox (the native one was being stretched to 100% by the global `input` rule and pushing the label text below it). The card background intensifies when ticked.