### PR TITLE
Add temporary unlisted /temp page for a single phone number

### DIFF
--- a/src/routes/temp/+page.svelte
+++ b/src/routes/temp/+page.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import { env } from '$env/dynamic/public'
+
+	// Set PUBLIC_TEMP_PHONE in Netlify (and in a local .env for dev).
+	// Kept out of the repo so the number is never committed to git history.
+	const phone = env.PUBLIC_TEMP_PHONE ?? ''
+</script>
+
+<svelte:head>
+	<title>·</title>
+	<meta name="robots" content="noindex, nofollow" />
+</svelte:head>
+
+<!-- data-pagefind-ignore excludes this page from the site's Pagefind search index -->
+<div class="temp" data-pagefind-ignore>
+	{#if phone}
+		<p class="number">{phone}</p>
+	{/if}
+</div>
+
+<style>
+	.temp {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		min-height: 50vh;
+	}
+
+	.number {
+		margin: 0;
+		font-size: clamp(1.75rem, 7vw, 3.5rem);
+		font-weight: 300;
+		letter-spacing: 0.04em;
+		text-align: center;
+		color: var(--text);
+	}
+</style>

--- a/src/routes/temp/+page.ts
+++ b/src/routes/temp/+page.ts
@@ -1,0 +1,5 @@
+// Temporary, intentionally unlisted page (not in the nav, sitemap, or on-site
+// search). The phone number is NOT stored in the repo — it's read at runtime
+// from the PUBLIC_TEMP_PHONE environment variable (set in Netlify). For that to
+// work the page must run as an edge function rather than being prerendered.
+export const prerender = false


### PR DESCRIPTION
## What

Adds a temporary, intentionally unlisted page at **`/temp`** that displays a single phone number, centered, and nothing else.

## How the number stays out of this (public) repo

The page does **not** contain the number. It reads it at runtime from the `PUBLIC_TEMP_PHONE` environment variable — the same mechanism the site already uses for `PUBLIC_SENTRY_DSN` etc. Set it in **Netlify → Site settings → Environment variables** and redeploy. To change or remove the number later, edit that variable (no code change). If it's unset, the page renders blank.

The page is `prerender = false` so the env value is read at request time on the edge, rather than baked in at build.

## Kept out of discovery

- **On-site search** — `data-pagefind-ignore` excludes it from the Pagefind index.
- **Search engines** — `<meta name="robots" content="noindex, nofollow">`.
- **Sitemap / nav** — the sitemap only lists blog posts and nothing links here, so it's reachable only by knowing the URL.

## Verified

Ran the dev server with a placeholder `PUBLIC_TEMP_PHONE` and confirmed: the number renders from the env var, `data-pagefind-ignore` is present, and `robots` is `noindex, nofollow`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)