### PR TITLE
Emphasize nonviolence on FAQ and About pages

### DIFF
--- a/src/posts/faq.md
+++ b/src/posts/faq.md
@@ -16,7 +16,7 @@ description: Frequently asked questions about PauseAI and the risks of superinte
 
 ## Who are you?
 
-We are a community of volunteers and [local communities](/communities) coordinated by a [non-profit organization](/organization) that aims to mitigate the [risks of AI](/risks).
+We are a community of volunteers and [local communities](/communities) coordinated by a [non-profit organization](/organization) that aims to mitigate the [risks of AI](/risks) **through strictly nonviolent means**.
 We aim to convince our governments to step in and [pause the development of superhuman AI](/proposal).
 We do this by informing the public, talking to decision-makers, and organizing [events](/communities#events).
 If you want to learn more about our history and the people behind PauseAI, check out our [about us](/about) page.

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -43,7 +43,7 @@
 	</p>
 
 	<p>
-		What started as one person's call to action has grown into a global grassroots movement with
+		What started as one person's call to action has grown into a global <strong>peaceful</strong> grassroots movement with
 		volunteers, <Link href="/national-groups">national leaders</Link>, and
 		<Link href="/local-communities">local communities</Link> across the world, all working toward the
 		same goal: pausing frontier AI development until we can prove it's safe and keep it under democratic


### PR DESCRIPTION
Title: Emphasize nonviolent, peaceful nature of the movement on FAQ and About pages. 

Body: Adds a few words (in bold) to make the movement's commitment to nonviolence explicit: the FAQ's "Who are you?" answer now says the organisation "aims to mitigate the risks of AI **through strictly nonviolent means**", and the About page now describes "a global **peaceful** grassroots movement". No other content changed.

